### PR TITLE
feat(core): v0.1.0 foundation — Error/Config/Ctx/Store/Auth traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.75"
+          toolchain: "1.85"
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project documentation (README, architecture, trademark compliance)
 - CI pipeline (fmt, clippy, test, MSRV)
 
+### Changed
+
+- **MSRV bumped from 1.75 to 1.85.** Modern crates in the foundation
+  dependency chain (`uuid`, `keyring`, transitive `getrandom 0.4.x`)
+  require `edition2024`, stabilized in Rust 1.85 (Feb 2025). Was flagged
+  as a likely requirement in the v0.1.0 design spec. Updated
+  `rust-toolchain.toml`, workspace `rust-version`, and CI matrix
+  accordingly.
+
 ## [0.0.1] — 2026-04-20
 
 Initial name reservation release on crates.io. No functional code yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ cargo test --workspace
 
 Requirements:
 
-- Rust 1.75+ (install via [rustup](https://rustup.rs))
+- Rust 1.85+ (install via [rustup](https://rustup.rs))
 - An Azure storage account for integration tests (optional for unit tests)
 
 ## Coding standards

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,44 @@
 version = 3
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -47,7 +79,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +90,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,12 +118,178 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "chrono",
  "futures",
+ "keyring",
+ "rusqlite",
+ "secrecy",
  "serde",
+ "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
+ "uuid",
 ]
+
+[[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.4.1",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.28",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "parking",
+ "polling 3.11.0",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io 2.6.0",
+ "async-lock 3.4.2",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -101,8 +299,26 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -111,16 +327,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.6.1",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -150,10 +452,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -169,14 +471,190 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures"
@@ -227,6 +705,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand 2.4.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,7 +740,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -267,10 +773,191 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -279,16 +966,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "keyring"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "linux-keyutils",
+ "secret-service",
+ "security-framework",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -321,6 +1083,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,7 +1108,19 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
 ]
 
 [[package]]
@@ -337,7 +1129,80 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -351,6 +1216,22 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -382,6 +1263,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.4.1",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,12 +1357,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -426,10 +1431,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -458,7 +1581,62 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -469,6 +1647,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -494,19 +1678,52 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -517,6 +1734,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand 2.4.1",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -536,7 +1766,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -560,9 +1790,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -573,8 +1803,60 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -595,7 +1877,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -638,10 +1920,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -650,10 +1955,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "wasi"
@@ -662,10 +1997,209 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -674,4 +2208,383 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "zbus"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener 2.5.3",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Data
 bytes = "1"
 
+# Store + crypto + identifiers
+rusqlite = { version = "0.31", features = ["bundled"] }
+keyring = "2"
+uuid = { version = "1", features = ["v4", "serde"] }
+secrecy = { version = "0.8", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+tempfile = "3"
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 license = "Apache-2.0"
 repository = "https://github.com/Horizon-Tech-doo/arkived"
 homepage = "https://arkived.app"
-rust-version = "1.75"
+rust-version = "1.85"
 
 [workspace.dependencies]
 # Azure SDK (preview — pin minor versions)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ and the repository hosts the workspace layout plus project docs.
 - `StorageBackend` trait (`pub(crate)`) and `Policy` trait skeletons in core
 - CLI skeleton with placeholder subcommands (clap)
 - Apache-2.0 license, Contributor Covenant v2.1, SECURITY policy
-- CI: fmt, clippy, test matrix (Linux/macOS/Windows), MSRV 1.75
+- CI: fmt, clippy, test matrix (Linux/macOS/Windows), MSRV 1.85
 
 ### 🟡 Stage 3 (partial) — Desktop app shell
 

--- a/app/README.md
+++ b/app/README.md
@@ -50,7 +50,7 @@ app/
 │   └── lib/ipc.ts         # invoke() wrapper with browser fallback
 └── src-tauri/
     ├── Cargo.toml         # Tauri 2 backend (excluded from root workspace)
-    ├── rust-toolchain.toml  # stable (Tauri 2 needs ≥1.77, workspace is 1.75)
+    ├── rust-toolchain.toml  # stable (Tauri 2 needs ≥1.77, workspace is 1.85)
     ├── tauri.conf.json
     ├── capabilities/default.json
     ├── icons/icon.png     # placeholder (replace before bundle)

--- a/crates/arkived-core/Cargo.toml
+++ b/crates/arkived-core/Cargo.toml
@@ -18,12 +18,23 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
+rusqlite = { workspace = true }
+keyring = { workspace = true }
+uuid = { workspace = true }
+secrecy = { workspace = true }
+chrono = { workspace = true }
 
 # Azure — uncomment in Stage 1 as you wire up AzureBackend:
 # azure_core = { workspace = true }
 # azure_identity = { workspace = true }
 # azure_storage = { workspace = true }
 # azure_storage_blobs = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "test-util"] }

--- a/crates/arkived-core/src/auth/credentials.rs
+++ b/crates/arkived-core/src/auth/credentials.rs
@@ -24,7 +24,9 @@ pub struct OsKeyring {
 impl OsKeyring {
     /// Create a new keyring scoped to `service`. All keys are namespaced by this.
     pub fn new(service: impl Into<String>) -> Self {
-        Self { service: service.into() }
+        Self {
+            service: service.into(),
+        }
     }
 
     fn entry(&self, key: &str) -> Result<keyring::Entry, Error> {
@@ -45,7 +47,9 @@ impl CredentialStore for OsKeyring {
             .get_password()
             .map(SecretString::new)
             .map_err(|e| match e {
-                keyring::Error::NoEntry => Error::NotFound { resource: format!("keychain:{key}") },
+                keyring::Error::NoEntry => Error::NotFound {
+                    resource: format!("keychain:{key}"),
+                },
                 other => Error::AuthFailed(format!("keyring get: {other}")),
             })
     }

--- a/crates/arkived-core/src/auth/credentials.rs
+++ b/crates/arkived-core/src/auth/credentials.rs
@@ -1,0 +1,3 @@
+//! `CredentialStore` trait — persists per-connection secrets in the OS keychain.
+//!
+//! Full `OsKeyring` impl lands in Task 8.

--- a/crates/arkived-core/src/auth/credentials.rs
+++ b/crates/arkived-core/src/auth/credentials.rs
@@ -1,3 +1,94 @@
-//! `CredentialStore` trait — persists per-connection secrets in the OS keychain.
-//!
-//! Full `OsKeyring` impl lands in Task 8.
+//! `CredentialStore` trait + OS-keychain-backed impl.
+
+use crate::Error;
+use secrecy::{ExposeSecret, SecretString};
+
+/// Persists per-connection secrets in the OS keychain. No plaintext on disk.
+pub trait CredentialStore: Send + Sync {
+    /// Store a secret under `key`.
+    fn put(&self, key: &str, secret: &SecretString) -> Result<(), Error>;
+    /// Retrieve a secret previously stored under `key`.
+    fn get(&self, key: &str) -> Result<SecretString, Error>;
+    /// Remove a secret. Missing keys are not an error (idempotent).
+    fn delete(&self, key: &str) -> Result<(), Error>;
+}
+
+/// OS-native keychain impl via the `keyring` crate.
+/// - macOS: Keychain
+/// - Windows: Credential Manager
+/// - Linux: Secret Service (gnome-keyring/KWallet)
+pub struct OsKeyring {
+    service: String,
+}
+
+impl OsKeyring {
+    /// Create a new keyring scoped to `service`. All keys are namespaced by this.
+    pub fn new(service: impl Into<String>) -> Self {
+        Self { service: service.into() }
+    }
+
+    fn entry(&self, key: &str) -> Result<keyring::Entry, Error> {
+        keyring::Entry::new(&self.service, key)
+            .map_err(|e| Error::AuthFailed(format!("keyring entry: {e}")))
+    }
+}
+
+impl CredentialStore for OsKeyring {
+    fn put(&self, key: &str, secret: &SecretString) -> Result<(), Error> {
+        self.entry(key)?
+            .set_password(secret.expose_secret())
+            .map_err(|e| Error::AuthFailed(format!("keyring put: {e}")))
+    }
+
+    fn get(&self, key: &str) -> Result<SecretString, Error> {
+        self.entry(key)?
+            .get_password()
+            .map(SecretString::new)
+            .map_err(|e| match e {
+                keyring::Error::NoEntry => Error::NotFound { resource: format!("keychain:{key}") },
+                other => Error::AuthFailed(format!("keyring get: {other}")),
+            })
+    }
+
+    fn delete(&self, key: &str) -> Result<(), Error> {
+        match self.entry(key)?.delete_password() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(Error::AuthFailed(format!("keyring delete: {e}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests hit the real OS keychain; they're marked #[ignore] so CI
+    // can skip them on headless runners. Run locally with:
+    //   cargo test -p arkived-core --lib auth::credentials::tests -- --ignored
+    #[test]
+    #[ignore]
+    fn roundtrip_against_os_keychain() {
+        let store = OsKeyring::new("arkived-test");
+        let key = format!("test-{}", uuid::Uuid::new_v4());
+        let secret = SecretString::new("super-secret".into());
+
+        assert!(matches!(store.get(&key), Err(Error::NotFound { .. })));
+
+        store.put(&key, &secret).unwrap();
+        let got = store.get(&key).unwrap();
+        assert_eq!(got.expose_secret(), "super-secret");
+
+        store.delete(&key).unwrap();
+        store.delete(&key).unwrap();
+        assert!(matches!(store.get(&key), Err(Error::NotFound { .. })));
+    }
+
+    // Non-ignored test exercises the types without touching the OS.
+    #[test]
+    fn credential_store_is_object_safe() {
+        fn assert_object_safe(_: &dyn CredentialStore) {}
+        let store = OsKeyring::new("arkived-compile-check");
+        assert_object_safe(&store);
+    }
+}

--- a/crates/arkived-core/src/auth/mod.rs
+++ b/crates/arkived-core/src/auth/mod.rs
@@ -40,18 +40,29 @@ mod tests {
 
     #[derive(Debug)]
     struct FakeCredential;
-    impl Credential for FakeCredential { fn kind(&self) -> AuthKind { AuthKind::Anonymous } }
+    impl Credential for FakeCredential {
+        fn kind(&self) -> AuthKind {
+            AuthKind::Anonymous
+        }
+    }
 
     struct FakeProvider;
     #[async_trait]
     impl AuthProvider for FakeProvider {
-        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
-        fn display_name(&self) -> &str { "fake" }
+        fn kind(&self) -> AuthKind {
+            AuthKind::Anonymous
+        }
+        fn display_name(&self) -> &str {
+            "fake"
+        }
         async fn credential(&self) -> Result<Arc<dyn Credential>, Error> {
             Ok(Arc::new(FakeCredential))
         }
         fn supports(&self, resource: ResourceKind) -> bool {
-            matches!(resource, ResourceKind::BlobContainer | ResourceKind::AdlsContainer)
+            matches!(
+                resource,
+                ResourceKind::BlobContainer | ResourceKind::AdlsContainer
+            )
         }
     }
 

--- a/crates/arkived-core/src/auth/mod.rs
+++ b/crates/arkived-core/src/auth/mod.rs
@@ -1,0 +1,68 @@
+//! `AuthProvider` trait and credential storage abstractions.
+//!
+//! Concrete impls (EntraDeviceCode, AccountKey, SasToken, etc.) land in
+//! the Auth plan. This module only defines the contract.
+
+pub mod credentials;
+
+use crate::types::{AuthKind, ResourceKind};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// An opaque credential factory consumed by the Azure SDK.
+///
+/// The return type is erased so every auth method can participate without
+/// leaking SDK types into downstream code. Concrete `AuthProvider` impls
+/// produce types implementing the Azure SDK's `TokenCredential`-equivalent
+/// traits; for v0.1.0 we use a local trait that the backend will bridge.
+pub trait Credential: Send + Sync + std::fmt::Debug {
+    /// The auth kind that produced this credential — useful for logging.
+    fn kind(&self) -> AuthKind;
+}
+
+/// Factory trait for credentials. One impl per auth method.
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    /// Classification of this provider — used for display and logging.
+    fn kind(&self) -> AuthKind;
+    /// Short human-readable name for this provider instance.
+    fn display_name(&self) -> &str;
+    /// Produce a fresh credential. Refresh semantics are implementation-defined.
+    async fn credential(&self) -> crate::Result<Arc<dyn Credential>>;
+    /// Whether this provider can be used to access the given resource kind.
+    fn supports(&self, resource: ResourceKind) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+
+    #[derive(Debug)]
+    struct FakeCredential;
+    impl Credential for FakeCredential { fn kind(&self) -> AuthKind { AuthKind::Anonymous } }
+
+    struct FakeProvider;
+    #[async_trait]
+    impl AuthProvider for FakeProvider {
+        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
+        fn display_name(&self) -> &str { "fake" }
+        async fn credential(&self) -> Result<Arc<dyn Credential>, Error> {
+            Ok(Arc::new(FakeCredential))
+        }
+        fn supports(&self, resource: ResourceKind) -> bool {
+            matches!(resource, ResourceKind::BlobContainer | ResourceKind::AdlsContainer)
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_object_works() {
+        let p: Box<dyn AuthProvider> = Box::new(FakeProvider);
+        assert_eq!(p.kind(), AuthKind::Anonymous);
+        assert_eq!(p.display_name(), "fake");
+        assert!(p.supports(ResourceKind::BlobContainer));
+        assert!(!p.supports(ResourceKind::Queue));
+        let cred = p.credential().await.unwrap();
+        assert_eq!(cred.kind(), AuthKind::Anonymous);
+    }
+}

--- a/crates/arkived-core/src/backend/mod.rs
+++ b/crates/arkived-core/src/backend/mod.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 /// **Stability: internal.** This trait is `pub(crate)` and may change without
 /// notice. Do not implement or depend on it outside this crate.
 #[async_trait]
+#[allow(dead_code)] // Placeholder until the Backend plan fleshes out concrete impls.
 pub(crate) trait StorageBackend: Send + Sync {
     /// A human-readable name for this backend (e.g. `"azure-blob"`).
     fn name(&self) -> &'static str;

--- a/crates/arkived-core/src/config/mod.rs
+++ b/crates/arkived-core/src/config/mod.rs
@@ -1,7 +1,7 @@
 //! Preferences-only TOML config. Zero credentials or connection metadata.
 
-use serde::{Deserialize, Serialize};
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// User/project-level preferences. Connection metadata lives in the
@@ -133,11 +133,12 @@ default_confirm = "auto"
     fn discover_finds_project_file_first() {
         let project = tempdir().unwrap();
         let user = tempdir().unwrap();
-        fs::write(project.path().join(".arkived.toml"), r#"default_format = "json""#).unwrap();
         fs::write(
-            user.path().join("config.toml"),
-            r#"default_format = "tsv""#,
-        ).unwrap();
+            project.path().join(".arkived.toml"),
+            r#"default_format = "json""#,
+        )
+        .unwrap();
+        fs::write(user.path().join("config.toml"), r#"default_format = "tsv""#).unwrap();
 
         let c = ArkivedConfig::discover(Some(project.path()), Some(user.path())).unwrap();
         assert_eq!(c.default_format, OutputFormat::Json);
@@ -146,7 +147,11 @@ default_confirm = "auto"
     #[test]
     fn discover_falls_back_to_user_then_defaults() {
         let user = tempdir().unwrap();
-        fs::write(user.path().join("config.toml"), r#"default_log_level = "trace""#).unwrap();
+        fs::write(
+            user.path().join("config.toml"),
+            r#"default_log_level = "trace""#,
+        )
+        .unwrap();
 
         let c = ArkivedConfig::discover(None, Some(user.path())).unwrap();
         assert_eq!(c.default_log_level, "trace");

--- a/crates/arkived-core/src/config/mod.rs
+++ b/crates/arkived-core/src/config/mod.rs
@@ -1,6 +1,8 @@
 //! Preferences-only TOML config. Zero credentials or connection metadata.
 
 use serde::{Deserialize, Serialize};
+use crate::Error;
+use std::path::Path;
 
 /// User/project-level preferences. Connection metadata lives in the
 /// [`Store`](crate::store::Store), never here.
@@ -61,6 +63,28 @@ impl ArkivedConfig {
     }
 }
 
+impl ArkivedConfig {
+    /// Discovery order: project (`<project>/.arkived.toml`) → user (`<user>/config.toml`) → defaults.
+    /// Missing files are silently skipped.
+    pub fn discover(project_dir: Option<&Path>, user_dir: Option<&Path>) -> Result<Self, Error> {
+        if let Some(p) = project_dir {
+            let path = p.join(".arkived.toml");
+            if path.exists() {
+                let s = std::fs::read_to_string(&path)?;
+                return Self::from_toml_str(&s).map_err(|e| Error::Other(e.into()));
+            }
+        }
+        if let Some(u) = user_dir {
+            let path = u.join("config.toml");
+            if path.exists() {
+                let s = std::fs::read_to_string(&path)?;
+                return Self::from_toml_str(&s).map_err(|e| Error::Other(e.into()));
+            }
+        }
+        Ok(Self::default())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,5 +124,35 @@ default_confirm = "auto"
         assert_eq!(c.default_log_level, "debug");
         assert_eq!(c.default_environment, "china");
         assert_eq!(c.default_confirm, ConfirmMode::Auto);
+    }
+
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn discover_finds_project_file_first() {
+        let project = tempdir().unwrap();
+        let user = tempdir().unwrap();
+        fs::write(project.path().join(".arkived.toml"), r#"default_format = "json""#).unwrap();
+        fs::write(
+            user.path().join("config.toml"),
+            r#"default_format = "tsv""#,
+        ).unwrap();
+
+        let c = ArkivedConfig::discover(Some(project.path()), Some(user.path())).unwrap();
+        assert_eq!(c.default_format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn discover_falls_back_to_user_then_defaults() {
+        let user = tempdir().unwrap();
+        fs::write(user.path().join("config.toml"), r#"default_log_level = "trace""#).unwrap();
+
+        let c = ArkivedConfig::discover(None, Some(user.path())).unwrap();
+        assert_eq!(c.default_log_level, "trace");
+        assert_eq!(c.default_format, OutputFormat::Table);
+
+        let c = ArkivedConfig::discover(None, None).unwrap();
+        assert_eq!(c, ArkivedConfig::default());
     }
 }

--- a/crates/arkived-core/src/config/mod.rs
+++ b/crates/arkived-core/src/config/mod.rs
@@ -1,0 +1,104 @@
+//! Preferences-only TOML config. Zero credentials or connection metadata.
+
+use serde::{Deserialize, Serialize};
+
+/// User/project-level preferences. Connection metadata lives in the
+/// [`Store`](crate::store::Store), never here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ArkivedConfig {
+    /// Default CLI output format when `--format` is not given.
+    pub default_format: OutputFormat,
+    /// Default log level — parsed as `tracing_subscriber::EnvFilter`.
+    pub default_log_level: String,
+    /// Default Azure environment (public, china, usgov, custom).
+    pub default_environment: String,
+    /// Default policy confirmation mode for destructive actions.
+    pub default_confirm: ConfirmMode,
+}
+
+impl Default for ArkivedConfig {
+    fn default() -> Self {
+        Self {
+            default_format: OutputFormat::Table,
+            default_log_level: "info".into(),
+            default_environment: "azure".into(),
+            default_confirm: ConfirmMode::Ask,
+        }
+    }
+}
+
+/// CLI output formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OutputFormat {
+    /// JSON — stable schema for machine consumers.
+    Json,
+    /// YAML — human-friendly machine format.
+    Yaml,
+    /// Table — default for TTY output.
+    Table,
+    /// Tab-separated values — for `awk`/`sort`/`uniq` pipelines.
+    Tsv,
+}
+
+/// Policy confirmation mode for non-interactive / scripted runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfirmMode {
+    /// Prompt interactively (default).
+    Ask,
+    /// Deny every destructive action unless explicitly allowed per-invocation.
+    Auto,
+    /// Approve all destructive actions without prompting (loud-logged; dangerous).
+    Yes,
+}
+
+impl ArkivedConfig {
+    /// Parse a config from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_spec() {
+        let c = ArkivedConfig::default();
+        assert_eq!(c.default_format, OutputFormat::Table);
+        assert_eq!(c.default_log_level, "info");
+        assert_eq!(c.default_environment, "azure");
+        assert_eq!(c.default_confirm, ConfirmMode::Ask);
+    }
+
+    #[test]
+    fn empty_toml_yields_defaults() {
+        let c = ArkivedConfig::from_toml_str("").unwrap();
+        assert_eq!(c, ArkivedConfig::default());
+    }
+
+    #[test]
+    fn partial_override_preserves_unset_defaults() {
+        let c = ArkivedConfig::from_toml_str(r#"default_format = "json""#).unwrap();
+        assert_eq!(c.default_format, OutputFormat::Json);
+        assert_eq!(c.default_log_level, "info");
+    }
+
+    #[test]
+    fn full_toml_roundtrip() {
+        let src = r#"
+default_format = "yaml"
+default_log_level = "debug"
+default_environment = "china"
+default_confirm = "auto"
+"#;
+        let c = ArkivedConfig::from_toml_str(src).unwrap();
+        assert_eq!(c.default_format, OutputFormat::Yaml);
+        assert_eq!(c.default_log_level, "debug");
+        assert_eq!(c.default_environment, "china");
+        assert_eq!(c.default_confirm, ConfirmMode::Auto);
+    }
+}

--- a/crates/arkived-core/src/ctx.rs
+++ b/crates/arkived-core/src/ctx.rs
@@ -1,0 +1,126 @@
+//! Shared context threaded through every backend call.
+//!
+//! Bundles the things every destructive operation needs: auth, policy,
+//! progress sink, cancellation, and a request-id for tracing correlation.
+
+use crate::auth::AuthProvider;
+use crate::policy::Policy;
+use crate::progress::{NoopSink, ProgressSink};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use uuid::Uuid;
+
+/// Cooperative cancellation token. Set once; cloneable across tasks.
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken {
+    flag: Arc<AtomicBool>,
+}
+
+impl CancellationToken {
+    /// Create a new uncancelled token.
+    pub fn new() -> Self { Self::default() }
+    /// Signal cancellation. Safe to call from any thread.
+    pub fn cancel(&self) { self.flag.store(true, Ordering::SeqCst); }
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool { self.flag.load(Ordering::SeqCst) }
+}
+
+/// Context bundle for a single logical operation. Cheap to clone (all Arc/value).
+#[derive(Clone)]
+pub struct Ctx {
+    /// Factory producing credentials for this operation.
+    pub auth: Arc<dyn AuthProvider>,
+    /// Confirmation gate for destructive actions.
+    pub policy: Arc<dyn Policy>,
+    /// Progress event sink.
+    pub progress: Arc<dyn ProgressSink>,
+    /// Cooperative cancel token.
+    pub cancel: CancellationToken,
+    /// Tracing correlation id.
+    pub request_id: Uuid,
+}
+
+impl Ctx {
+    /// Construct a new `Ctx` with a `NoopSink` progress sink and a fresh
+    /// cancellation token.
+    pub fn new(auth: Arc<dyn AuthProvider>, policy: Arc<dyn Policy>) -> Self {
+        Self {
+            auth,
+            policy,
+            progress: Arc::new(NoopSink),
+            cancel: CancellationToken::new(),
+            request_id: Uuid::new_v4(),
+        }
+    }
+
+    /// Override the progress sink.
+    pub fn with_progress(mut self, sink: Arc<dyn ProgressSink>) -> Self {
+        self.progress = sink;
+        self
+    }
+
+    /// Override the cancellation token (so multiple Ctx clones share cancel state).
+    pub fn with_cancel(mut self, token: CancellationToken) -> Self {
+        self.cancel = token;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::Credential;
+    use crate::policy::{Action, ActionContext, AllowAllPolicy, PolicyDecision};
+    use crate::progress::MemorySink;
+    use crate::types::{AuthKind, ResourceKind};
+    use async_trait::async_trait;
+
+    #[derive(Debug)]
+    struct FakeCred;
+    impl Credential for FakeCred { fn kind(&self) -> AuthKind { AuthKind::Anonymous } }
+
+    struct FakeAuth;
+    #[async_trait]
+    impl AuthProvider for FakeAuth {
+        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
+        fn display_name(&self) -> &str { "fake" }
+        async fn credential(&self) -> crate::Result<Arc<dyn Credential>> {
+            Ok(Arc::new(FakeCred))
+        }
+        fn supports(&self, _: ResourceKind) -> bool { true }
+    }
+
+    #[tokio::test]
+    async fn ctx_construction_and_allow_all_policy() {
+        let auth: Arc<dyn AuthProvider> = Arc::new(FakeAuth);
+        let policy: Arc<dyn Policy> = Arc::new(AllowAllPolicy);
+        let sink = Arc::new(MemorySink::new());
+        let ctx = Ctx::new(auth, policy).with_progress(sink.clone());
+
+        let decision = ctx.policy.confirm(
+            &Action { verb: "test".into(), target: "t".into(), summary: "s".into(), reversible: true },
+            &ActionContext::default(),
+        ).await;
+        assert_eq!(decision, PolicyDecision::Allow);
+
+        ctx.progress.emit(crate::progress::ProgressEvent::Complete).await;
+        assert_eq!(sink.events().len(), 1);
+    }
+
+    #[test]
+    fn cancellation_token_propagates_across_clones() {
+        let tok = CancellationToken::new();
+        assert!(!tok.is_cancelled());
+        let clone = tok.clone();
+        tok.cancel();
+        assert!(clone.is_cancelled());
+    }
+
+    #[test]
+    fn request_ids_are_unique() {
+        let auth: Arc<dyn AuthProvider> = Arc::new(FakeAuth);
+        let policy: Arc<dyn Policy> = Arc::new(AllowAllPolicy);
+        let a = Ctx::new(auth.clone(), policy.clone());
+        let b = Ctx::new(auth, policy);
+        assert_ne!(a.request_id, b.request_id);
+    }
+}

--- a/crates/arkived-core/src/ctx.rs
+++ b/crates/arkived-core/src/ctx.rs
@@ -6,7 +6,10 @@
 use crate::auth::AuthProvider;
 use crate::policy::Policy;
 use crate::progress::{NoopSink, ProgressSink};
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use uuid::Uuid;
 
 /// Cooperative cancellation token. Set once; cloneable across tasks.
@@ -17,11 +20,17 @@ pub struct CancellationToken {
 
 impl CancellationToken {
     /// Create a new uncancelled token.
-    pub fn new() -> Self { Self::default() }
+    pub fn new() -> Self {
+        Self::default()
+    }
     /// Signal cancellation. Safe to call from any thread.
-    pub fn cancel(&self) { self.flag.store(true, Ordering::SeqCst); }
+    pub fn cancel(&self) {
+        self.flag.store(true, Ordering::SeqCst);
+    }
     /// Whether cancellation has been requested.
-    pub fn is_cancelled(&self) -> bool { self.flag.load(Ordering::SeqCst) }
+    pub fn is_cancelled(&self) -> bool {
+        self.flag.load(Ordering::SeqCst)
+    }
 }
 
 /// Context bundle for a single logical operation. Cheap to clone (all Arc/value).
@@ -76,17 +85,27 @@ mod tests {
 
     #[derive(Debug)]
     struct FakeCred;
-    impl Credential for FakeCred { fn kind(&self) -> AuthKind { AuthKind::Anonymous } }
+    impl Credential for FakeCred {
+        fn kind(&self) -> AuthKind {
+            AuthKind::Anonymous
+        }
+    }
 
     struct FakeAuth;
     #[async_trait]
     impl AuthProvider for FakeAuth {
-        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
-        fn display_name(&self) -> &str { "fake" }
+        fn kind(&self) -> AuthKind {
+            AuthKind::Anonymous
+        }
+        fn display_name(&self) -> &str {
+            "fake"
+        }
         async fn credential(&self) -> crate::Result<Arc<dyn Credential>> {
             Ok(Arc::new(FakeCred))
         }
-        fn supports(&self, _: ResourceKind) -> bool { true }
+        fn supports(&self, _: ResourceKind) -> bool {
+            true
+        }
     }
 
     #[tokio::test]
@@ -96,13 +115,23 @@ mod tests {
         let sink = Arc::new(MemorySink::new());
         let ctx = Ctx::new(auth, policy).with_progress(sink.clone());
 
-        let decision = ctx.policy.confirm(
-            &Action { verb: "test".into(), target: "t".into(), summary: "s".into(), reversible: true },
-            &ActionContext::default(),
-        ).await;
+        let decision = ctx
+            .policy
+            .confirm(
+                &Action {
+                    verb: "test".into(),
+                    target: "t".into(),
+                    summary: "s".into(),
+                    reversible: true,
+                },
+                &ActionContext::default(),
+            )
+            .await;
         assert_eq!(decision, PolicyDecision::Allow);
 
-        ctx.progress.emit(crate::progress::ProgressEvent::Complete).await;
+        ctx.progress
+            .emit(crate::progress::ProgressEvent::Complete)
+            .await;
         assert_eq!(sink.events().len(), 1);
     }
 

--- a/crates/arkived-core/src/error.rs
+++ b/crates/arkived-core/src/error.rs
@@ -26,15 +26,26 @@ pub enum Error {
 
     /// Resource not found.
     #[error("not found: {resource}")]
-    NotFound { resource: String },
+    NotFound {
+        /// The canonical path or identifier of the missing resource.
+        resource: String,
+    },
 
     /// A conflict (ETag mismatch, lease held, etc.).
     #[error("conflict{}: {detail}", etag.as_deref().map(|e| format!(" (etag {e})")).unwrap_or_default())]
-    Conflict { detail: String, etag: Option<String> },
+    Conflict {
+        /// Human-readable description of the conflict.
+        detail: String,
+        /// The ETag returned by the server, if available.
+        etag: Option<String>,
+    },
 
     /// Server throttled; caller may retry after the given duration.
     #[error("throttled by server (retry after {}s)", retry_after.as_secs())]
-    Throttled { retry_after: std::time::Duration },
+    Throttled {
+        /// Server-recommended backoff before retry.
+        retry_after: std::time::Duration,
+    },
 
     /// Transient network error.
     #[error("network transient: {0}")]

--- a/crates/arkived-core/src/error.rs
+++ b/crates/arkived-core/src/error.rs
@@ -16,7 +16,31 @@ pub enum Error {
     #[error("storage backend error: {0}")]
     Backend(String),
 
-    /// An authentication error.
+    /// An authentication error with detail.
+    #[error("authentication failed: {0}")]
+    AuthFailed(String),
+
+    /// The current credential has expired.
+    #[error("authentication expired; sign in again")]
+    AuthExpired,
+
+    /// Resource not found.
+    #[error("not found: {resource}")]
+    NotFound { resource: String },
+
+    /// A conflict (ETag mismatch, lease held, etc.).
+    #[error("conflict{}: {detail}", etag.as_deref().map(|e| format!(" (etag {e})")).unwrap_or_default())]
+    Conflict { detail: String, etag: Option<String> },
+
+    /// Server throttled; caller may retry after the given duration.
+    #[error("throttled by server (retry after {}s)", retry_after.as_secs())]
+    Throttled { retry_after: std::time::Duration },
+
+    /// Transient network error.
+    #[error("network transient: {0}")]
+    NetworkTransient(String),
+
+    /// Generic authentication error (for migration — prefer AuthFailed or AuthExpired).
     #[error("authentication error: {0}")]
     Auth(String),
 
@@ -27,4 +51,35 @@ pub enum Error {
     /// A catch-all for other errors.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn error_variants_display() {
+        assert_eq!(
+            Error::NotFound { resource: "container/foo".into() }.to_string(),
+            "not found: container/foo"
+        );
+        assert_eq!(
+            Error::Conflict { detail: "etag mismatch".into(), etag: Some("0xABC".into()) }.to_string(),
+            "conflict (etag 0xABC): etag mismatch"
+        );
+        assert_eq!(
+            Error::Throttled { retry_after: Duration::from_secs(5) }.to_string(),
+            "throttled by server (retry after 5s)"
+        );
+        assert_eq!(Error::AuthExpired.to_string(), "authentication expired; sign in again");
+        assert!(matches!(
+            Error::NetworkTransient("dns".into()),
+            Error::NetworkTransient(_)
+        ));
+        assert!(matches!(
+            Error::AuthFailed("bad creds".into()),
+            Error::AuthFailed(_)
+        ));
+    }
 }

--- a/crates/arkived-core/src/error.rs
+++ b/crates/arkived-core/src/error.rs
@@ -72,18 +72,31 @@ mod tests {
     #[test]
     fn error_variants_display() {
         assert_eq!(
-            Error::NotFound { resource: "container/foo".into() }.to_string(),
+            Error::NotFound {
+                resource: "container/foo".into()
+            }
+            .to_string(),
             "not found: container/foo"
         );
         assert_eq!(
-            Error::Conflict { detail: "etag mismatch".into(), etag: Some("0xABC".into()) }.to_string(),
+            Error::Conflict {
+                detail: "etag mismatch".into(),
+                etag: Some("0xABC".into())
+            }
+            .to_string(),
             "conflict (etag 0xABC): etag mismatch"
         );
         assert_eq!(
-            Error::Throttled { retry_after: Duration::from_secs(5) }.to_string(),
+            Error::Throttled {
+                retry_after: Duration::from_secs(5)
+            }
+            .to_string(),
             "throttled by server (retry after 5s)"
         );
-        assert_eq!(Error::AuthExpired.to_string(), "authentication expired; sign in again");
+        assert_eq!(
+            Error::AuthExpired.to_string(),
+            "authentication expired; sign in again"
+        );
         assert!(matches!(
             Error::NetworkTransient("dns".into()),
             Error::NetworkTransient(_)

--- a/crates/arkived-core/src/error.rs
+++ b/crates/arkived-core/src/error.rs
@@ -51,10 +51,6 @@ pub enum Error {
     #[error("network transient: {0}")]
     NetworkTransient(String),
 
-    /// Generic authentication error (for migration — prefer AuthFailed or AuthExpired).
-    #[error("authentication error: {0}")]
-    Auth(String),
-
     /// An I/O error.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -19,6 +19,7 @@
 #![deny(rust_2018_idioms, unsafe_code, missing_docs)]
 #![warn(clippy::all)]
 
+pub mod auth;
 pub mod config;
 pub mod error;
 pub mod policy;
@@ -27,6 +28,7 @@ pub mod types;
 
 pub(crate) mod backend;
 
+pub use auth::{AuthProvider, Credential};
 pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -32,7 +32,7 @@ pub(crate) mod backend;
 
 pub use auth::{AuthProvider, Credential};
 pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
-pub use ctx::{Ctx, CancellationToken};
+pub use ctx::{CancellationToken, Ctx};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};
 pub use store::Store;

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod config;
 pub mod error;
 pub mod policy;
+pub mod progress;
 
 pub(crate) mod backend;
 

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -30,6 +30,13 @@ pub mod types;
 
 pub(crate) mod backend;
 
+// Re-export policy: the crate root surfaces top-level contracts (traits,
+// primary entry points, shared error types). Data-record types that only
+// matter alongside a specific subsystem (SignIn, Subscription, StorageAccount,
+// AttachedResource, CurrentContext, PolicyAllowEntry; CredentialStore, OsKeyring;
+// ProgressEvent, ProgressSink, NoopSink, MemorySink) stay reachable via their
+// module path (`arkived_core::store::SignIn` etc.) to keep the top-level namespace
+// focused.
 pub use auth::{AuthProvider, Credential};
 pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
 pub use ctx::{CancellationToken, Ctx};

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -19,10 +19,12 @@
 #![deny(rust_2018_idioms, unsafe_code, missing_docs)]
 #![warn(clippy::all)]
 
+pub mod config;
 pub mod error;
 pub mod policy;
 
 pub(crate) mod backend;
 
+pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod ctx;
 pub mod error;
 pub mod policy;
 pub mod progress;
+pub mod store;
 pub mod types;
 
 pub(crate) mod backend;
@@ -34,4 +35,5 @@ pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
 pub use ctx::{Ctx, CancellationToken};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};
+pub use store::Store;
 pub use types::{AuthKind, AzureEnvironment, ResourceKind};

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod auth;
 pub mod config;
+pub mod ctx;
 pub mod error;
 pub mod policy;
 pub mod progress;
@@ -30,6 +31,7 @@ pub(crate) mod backend;
 
 pub use auth::{AuthProvider, Credential};
 pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
+pub use ctx::{Ctx, CancellationToken};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};
 pub use types::{AuthKind, AzureEnvironment, ResourceKind};

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -23,9 +23,11 @@ pub mod config;
 pub mod error;
 pub mod policy;
 pub mod progress;
+pub mod types;
 
 pub(crate) mod backend;
 
 pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};
+pub use types::{AuthKind, AzureEnvironment, ResourceKind};

--- a/crates/arkived-core/src/progress/mod.rs
+++ b/crates/arkived-core/src/progress/mod.rs
@@ -47,7 +47,9 @@ pub struct MemorySink {
 
 impl MemorySink {
     /// Construct an empty `MemorySink`.
-    pub fn new() -> Self { Self::default() }
+    pub fn new() -> Self {
+        Self::default()
+    }
 
     /// Snapshot of all events captured so far.
     pub fn events(&self) -> Vec<ProgressEvent> {
@@ -77,7 +79,11 @@ mod tests {
     async fn memory_sink_collects_events() {
         let s = MemorySink::new();
         s.emit(ProgressEvent::Start { total: Some(100) }).await;
-        s.emit(ProgressEvent::Update { current: 50, rate: Some(42.0) }).await;
+        s.emit(ProgressEvent::Update {
+            current: 50,
+            rate: Some(42.0),
+        })
+        .await;
         s.emit(ProgressEvent::Complete).await;
         assert_eq!(s.events().len(), 3);
         assert_eq!(s.events()[0], ProgressEvent::Start { total: Some(100) });

--- a/crates/arkived-core/src/progress/mod.rs
+++ b/crates/arkived-core/src/progress/mod.rs
@@ -1,0 +1,85 @@
+//! Progress reporting for long-running backend operations.
+
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+/// A single progress event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProgressEvent {
+    /// Operation started with optional known total size (bytes or items).
+    Start {
+        /// Known total size in bytes or items; `None` if unknown.
+        total: Option<u64>,
+    },
+    /// Progress update: current bytes/items completed and instantaneous rate.
+    Update {
+        /// Current bytes/items completed so far.
+        current: u64,
+        /// Instantaneous rate (items or bytes per second), if computable.
+        rate: Option<f64>,
+    },
+    /// Operation completed successfully.
+    Complete,
+    /// Operation failed with a reason.
+    Error(String),
+}
+
+/// Sink that receives progress events during long operations.
+#[async_trait]
+pub trait ProgressSink: Send + Sync {
+    /// Emit a single progress event. Implementations should be non-blocking.
+    async fn emit(&self, event: ProgressEvent);
+}
+
+/// A no-op sink for call sites that don't want progress.
+pub struct NoopSink;
+
+#[async_trait]
+impl ProgressSink for NoopSink {
+    async fn emit(&self, _event: ProgressEvent) {}
+}
+
+/// A sink that collects all events in memory; useful for tests.
+#[derive(Default)]
+pub struct MemorySink {
+    events: Arc<Mutex<Vec<ProgressEvent>>>,
+}
+
+impl MemorySink {
+    /// Construct an empty `MemorySink`.
+    pub fn new() -> Self { Self::default() }
+
+    /// Snapshot of all events captured so far.
+    pub fn events(&self) -> Vec<ProgressEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ProgressSink for MemorySink {
+    async fn emit(&self, event: ProgressEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn noop_sink_swallows() {
+        let s = NoopSink;
+        s.emit(ProgressEvent::Start { total: Some(10) }).await;
+        s.emit(ProgressEvent::Complete).await;
+    }
+
+    #[tokio::test]
+    async fn memory_sink_collects_events() {
+        let s = MemorySink::new();
+        s.emit(ProgressEvent::Start { total: Some(100) }).await;
+        s.emit(ProgressEvent::Update { current: 50, rate: Some(42.0) }).await;
+        s.emit(ProgressEvent::Complete).await;
+        assert_eq!(s.events().len(), 3);
+        assert_eq!(s.events()[0], ProgressEvent::Start { total: Some(100) });
+    }
+}

--- a/crates/arkived-core/src/store/attached_resource.rs
+++ b/crates/arkived-core/src/store/attached_resource.rs
@@ -1,9 +1,9 @@
 //! CRUD for the `attached_resource` table — resources attached directly via
 //! SAS or connection string, outside a sign-in.
 
-use crate::Error;
 use crate::store::Store;
 use crate::types::{AuthKind, ResourceKind};
+use crate::Error;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
@@ -52,22 +52,31 @@ impl Store {
                  FROM attached_resource WHERE id = ?1",
                 params![id],
                 row_to_attached,
-            ).optional().map_err(|e| Error::Other(anyhow::anyhow!("attached_resource get: {e}")))
+            )
+            .optional()
+            .map_err(|e| Error::Other(anyhow::anyhow!("attached_resource get: {e}")))
         })
     }
 
     /// List all attached resources, ordered by display name.
     pub fn attached_resource_list(&self) -> Result<Vec<AttachedResource>, Error> {
         self.with_conn(|c| {
-            let mut stmt = c.prepare(
-                "SELECT id, display_name, resource_kind, endpoint, auth_kind, keychain_ref
-                 FROM attached_resource ORDER BY display_name"
-            ).map_err(|e| Error::Other(anyhow::anyhow!("attached_resource list prepare: {e}")))?;
-            let rows = stmt.query_map([], row_to_attached)
+            let mut stmt = c
+                .prepare(
+                    "SELECT id, display_name, resource_kind, endpoint, auth_kind, keychain_ref
+                 FROM attached_resource ORDER BY display_name",
+                )
+                .map_err(|e| {
+                    Error::Other(anyhow::anyhow!("attached_resource list prepare: {e}"))
+                })?;
+            let rows = stmt
+                .query_map([], row_to_attached)
                 .map_err(|e| Error::Other(anyhow::anyhow!("attached_resource list query: {e}")))?;
             let mut out = Vec::new();
             for r in rows {
-                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("attached_resource list row: {e}")))?);
+                out.push(r.map_err(|e| {
+                    Error::Other(anyhow::anyhow!("attached_resource list row: {e}"))
+                })?);
             }
             Ok(out)
         })
@@ -89,11 +98,13 @@ fn row_to_attached(row: &rusqlite::Row<'_>) -> rusqlite::Result<AttachedResource
     Ok(AttachedResource {
         id: row.get(0)?,
         display_name: row.get(1)?,
-        resource_kind: serde_json::from_str(&rk)
-            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e)))?,
+        resource_kind: serde_json::from_str(&rk).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e))
+        })?,
         endpoint: row.get(3)?,
-        auth_kind: serde_json::from_str(&ak)
-            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e)))?,
+        auth_kind: serde_json::from_str(&ak).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e))
+        })?,
         keychain_ref: row.get(5)?,
     })
 }

--- a/crates/arkived-core/src/store/attached_resource.rs
+++ b/crates/arkived-core/src/store/attached_resource.rs
@@ -1,0 +1,131 @@
+//! CRUD for the `attached_resource` table — resources attached directly via
+//! SAS or connection string, outside a sign-in.
+
+use crate::Error;
+use crate::store::Store;
+use crate::types::{AuthKind, ResourceKind};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// A resource attached via SAS URL, connection string, or account key —
+/// tracked outside any Entra sign-in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttachedResource {
+    /// Opaque caller-chosen id (typically a UUID).
+    pub id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// What kind of resource this is.
+    pub resource_kind: ResourceKind,
+    /// Endpoint URL (with container/path if applicable).
+    pub endpoint: String,
+    /// Which auth method this attachment uses.
+    pub auth_kind: AuthKind,
+    /// Reference into the OS keychain for the actual secret.
+    pub keychain_ref: String,
+}
+
+impl Store {
+    /// Insert a new attached resource. Fails on duplicate `id`.
+    pub fn attached_resource_insert(&self, a: &AttachedResource) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute(
+                "INSERT INTO attached_resource (id, display_name, resource_kind, endpoint, auth_kind, keychain_ref)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    a.id, a.display_name,
+                    serde_json::to_string(&a.resource_kind).unwrap(),
+                    a.endpoint,
+                    serde_json::to_string(&a.auth_kind).unwrap(),
+                    a.keychain_ref,
+                ],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("attached_resource insert: {e}")))?;
+            Ok(())
+        })
+    }
+
+    /// Fetch an attached resource by id. Returns `Ok(None)` if not found.
+    pub fn attached_resource_get(&self, id: &str) -> Result<Option<AttachedResource>, Error> {
+        self.with_conn(|c| {
+            c.query_row(
+                "SELECT id, display_name, resource_kind, endpoint, auth_kind, keychain_ref
+                 FROM attached_resource WHERE id = ?1",
+                params![id],
+                row_to_attached,
+            ).optional().map_err(|e| Error::Other(anyhow::anyhow!("attached_resource get: {e}")))
+        })
+    }
+
+    /// List all attached resources, ordered by display name.
+    pub fn attached_resource_list(&self) -> Result<Vec<AttachedResource>, Error> {
+        self.with_conn(|c| {
+            let mut stmt = c.prepare(
+                "SELECT id, display_name, resource_kind, endpoint, auth_kind, keychain_ref
+                 FROM attached_resource ORDER BY display_name"
+            ).map_err(|e| Error::Other(anyhow::anyhow!("attached_resource list prepare: {e}")))?;
+            let rows = stmt.query_map([], row_to_attached)
+                .map_err(|e| Error::Other(anyhow::anyhow!("attached_resource list query: {e}")))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("attached_resource list row: {e}")))?);
+            }
+            Ok(out)
+        })
+    }
+
+    /// Delete an attached resource by id. Does not remove the keychain entry.
+    pub fn attached_resource_delete(&self, id: &str) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute("DELETE FROM attached_resource WHERE id = ?1", params![id])
+                .map_err(|e| Error::Other(anyhow::anyhow!("attached_resource delete: {e}")))?;
+            Ok(())
+        })
+    }
+}
+
+fn row_to_attached(row: &rusqlite::Row<'_>) -> rusqlite::Result<AttachedResource> {
+    let rk: String = row.get(2)?;
+    let ak: String = row.get(4)?;
+    Ok(AttachedResource {
+        id: row.get(0)?,
+        display_name: row.get(1)?,
+        resource_kind: serde_json::from_str(&rk)
+            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e)))?,
+        endpoint: row.get(3)?,
+        auth_kind: serde_json::from_str(&ak)
+            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e)))?,
+        keychain_ref: row.get(5)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+
+    fn sample() -> AttachedResource {
+        AttachedResource {
+            id: uuid::Uuid::new_v4().to_string(),
+            display_name: "dev-readonly".into(),
+            resource_kind: ResourceKind::BlobContainer,
+            endpoint: "https://acmeprod.blob.core.windows.net/raw-telemetry".into(),
+            auth_kind: AuthKind::SasToken,
+            keychain_ref: "arkived:connection:abcd".into(),
+        }
+    }
+
+    #[test]
+    fn insert_get_list_delete() {
+        let s = Store::open_in_memory().unwrap();
+        let a = sample();
+        s.attached_resource_insert(&a).unwrap();
+        let got = s.attached_resource_get(&a.id).unwrap().unwrap();
+        assert_eq!(got, a);
+
+        let list = s.attached_resource_list().unwrap();
+        assert_eq!(list.len(), 1);
+
+        s.attached_resource_delete(&a.id).unwrap();
+        assert!(s.attached_resource_get(&a.id).unwrap().is_none());
+    }
+}

--- a/crates/arkived-core/src/store/context.rs
+++ b/crates/arkived-core/src/store/context.rs
@@ -1,8 +1,8 @@
 //! Current-context 3-tuple (sign_in, subscription, account) persisted in
 //! the `context` key-value table.
 
-use crate::Error;
 use crate::store::Store;
+use crate::Error;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
@@ -23,10 +23,12 @@ impl Store {
     pub fn context_get(&self) -> Result<CurrentContext, Error> {
         self.with_conn(|c| {
             let get = |k: &str| -> Result<Option<String>, Error> {
-                c.query_row("SELECT v FROM context WHERE k = ?1", params![k], |r| r.get::<_, Option<String>>(0))
-                    .optional()
-                    .map(|opt| opt.flatten())
-                    .map_err(|e| Error::Other(anyhow::anyhow!("context get {k}: {e}")))
+                c.query_row("SELECT v FROM context WHERE k = ?1", params![k], |r| {
+                    r.get::<_, Option<String>>(0)
+                })
+                .optional()
+                .map(|opt| opt.flatten())
+                .map_err(|e| Error::Other(anyhow::anyhow!("context get {k}: {e}")))
             };
             Ok(CurrentContext {
                 sign_in_id: get("current_sign_in")?,
@@ -57,7 +59,8 @@ impl Store {
                 "INSERT INTO context (k, v) VALUES (?1, ?2)
                  ON CONFLICT(k) DO UPDATE SET v = excluded.v",
                 params![key, value],
-            ).map_err(|e| Error::Other(anyhow::anyhow!("context set {key}: {e}")))?;
+            )
+            .map_err(|e| Error::Other(anyhow::anyhow!("context set {key}: {e}")))?;
             Ok(())
         })
     }

--- a/crates/arkived-core/src/store/context.rs
+++ b/crates/arkived-core/src/store/context.rs
@@ -1,0 +1,104 @@
+//! Current-context 3-tuple (sign_in, subscription, account) persisted in
+//! the `context` key-value table.
+
+use crate::Error;
+use crate::store::Store;
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// The currently-selected context. All three fields are independent; any may
+/// be `None`. CLI write commands require `account_name` resolved via `-A`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentContext {
+    /// The current Entra sign-in, or `None` if no sign-in active.
+    pub sign_in_id: Option<String>,
+    /// The current subscription within the sign-in, or `None`.
+    pub subscription_id: Option<String>,
+    /// The current storage account within the subscription, or `None`.
+    pub account_name: Option<String>,
+}
+
+impl Store {
+    /// Fetch the full current context.
+    pub fn context_get(&self) -> Result<CurrentContext, Error> {
+        self.with_conn(|c| {
+            let get = |k: &str| -> Result<Option<String>, Error> {
+                c.query_row("SELECT v FROM context WHERE k = ?1", params![k], |r| r.get::<_, Option<String>>(0))
+                    .optional()
+                    .map(|opt| opt.flatten())
+                    .map_err(|e| Error::Other(anyhow::anyhow!("context get {k}: {e}")))
+            };
+            Ok(CurrentContext {
+                sign_in_id: get("current_sign_in")?,
+                subscription_id: get("current_subscription")?,
+                account_name: get("current_account")?,
+            })
+        })
+    }
+
+    /// Set the current sign-in (or clear with `None`).
+    pub fn context_set_sign_in(&self, id: Option<&str>) -> Result<(), Error> {
+        self.context_set("current_sign_in", id)
+    }
+
+    /// Set the current subscription (or clear with `None`).
+    pub fn context_set_subscription(&self, id: Option<&str>) -> Result<(), Error> {
+        self.context_set("current_subscription", id)
+    }
+
+    /// Set the current storage account (or clear with `None`).
+    pub fn context_set_account(&self, name: Option<&str>) -> Result<(), Error> {
+        self.context_set("current_account", name)
+    }
+
+    fn context_set(&self, key: &str, value: Option<&str>) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute(
+                "INSERT INTO context (k, v) VALUES (?1, ?2)
+                 ON CONFLICT(k) DO UPDATE SET v = excluded.v",
+                params![key, value],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("context set {key}: {e}")))?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+
+    #[test]
+    fn default_context_is_empty() {
+        let s = Store::open_in_memory().unwrap();
+        assert_eq!(s.context_get().unwrap(), CurrentContext::default());
+    }
+
+    #[test]
+    fn set_and_get_each_key() {
+        let s = Store::open_in_memory().unwrap();
+        s.context_set_sign_in(Some("si-1")).unwrap();
+        s.context_set_subscription(Some("sub-1")).unwrap();
+        s.context_set_account(Some("acmeprod")).unwrap();
+        let ctx = s.context_get().unwrap();
+        assert_eq!(ctx.sign_in_id.as_deref(), Some("si-1"));
+        assert_eq!(ctx.subscription_id.as_deref(), Some("sub-1"));
+        assert_eq!(ctx.account_name.as_deref(), Some("acmeprod"));
+    }
+
+    #[test]
+    fn clearing_by_setting_none() {
+        let s = Store::open_in_memory().unwrap();
+        s.context_set_account(Some("acmeprod")).unwrap();
+        s.context_set_account(None).unwrap();
+        assert_eq!(s.context_get().unwrap().account_name, None);
+    }
+
+    #[test]
+    fn update_overwrites() {
+        let s = Store::open_in_memory().unwrap();
+        s.context_set_sign_in(Some("si-1")).unwrap();
+        s.context_set_sign_in(Some("si-2")).unwrap();
+        assert_eq!(s.context_get().unwrap().sign_in_id.as_deref(), Some("si-2"));
+    }
+}

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -234,3 +234,6 @@ pub use sign_in::SignIn;
 
 pub mod subscription;
 pub use subscription::Subscription;
+
+pub mod storage_account;
+pub use storage_account::StorageAccount;

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -243,3 +243,6 @@ pub use attached_resource::AttachedResource;
 
 pub mod context;
 pub use context::CurrentContext;
+
+pub mod policy_memory;
+pub use policy_memory::PolicyAllowEntry;

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -27,6 +27,8 @@ impl Store {
     pub fn open(path: &Path) -> Result<Self, Error> {
         let conn = Connection::open(path)
             .map_err(|e| Error::Other(anyhow::anyhow!("open store: {e}")))?;
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .map_err(|e| Error::Other(anyhow::anyhow!("enable foreign_keys: {e}")))?;
         let store = Self { conn: Mutex::new(conn) };
         store.migrate()?;
         Ok(store)
@@ -36,6 +38,8 @@ impl Store {
     pub fn open_in_memory() -> Result<Self, Error> {
         let conn = Connection::open_in_memory()
             .map_err(|e| Error::Other(anyhow::anyhow!("open in-memory store: {e}")))?;
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .map_err(|e| Error::Other(anyhow::anyhow!("enable foreign_keys: {e}")))?;
         let store = Self { conn: Mutex::new(conn) };
         store.migrate()?;
         Ok(store)
@@ -212,6 +216,16 @@ mod tests {
                 .map_err(|e| Error::Other(anyhow::anyhow!(e)))
         }).unwrap();
         assert_eq!(count, 0, "policy_memory must be truncated on every open");
+    }
+
+    #[test]
+    fn foreign_keys_enforced_by_default() {
+        let s = Store::open_in_memory().unwrap();
+        let enabled: i32 = s.with_conn(|c| {
+            c.query_row("PRAGMA foreign_keys", [], |r| r.get(0))
+                .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+        }).unwrap();
+        assert_eq!(enabled, 1, "foreign_keys pragma must default to ON");
     }
 }
 

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -214,3 +214,6 @@ mod tests {
         assert_eq!(count, 0, "policy_memory must be truncated on every open");
     }
 }
+
+pub mod sign_in;
+pub use sign_in::SignIn;

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -67,6 +67,9 @@ impl Store {
             ).map_err(|e| Error::Other(anyhow::anyhow!("record schema version: {e}")))?;
         }
 
+        conn.execute("DELETE FROM policy_memory", [])
+            .map_err(|e| Error::Other(anyhow::anyhow!("truncate policy_memory: {e}")))?;
+
         Ok(())
     }
 
@@ -177,5 +180,37 @@ mod tests {
         store.migrate().unwrap();
         store.migrate().unwrap();
         assert_eq!(store.schema_version(), SCHEMA_VERSION);
+    }
+
+    use chrono::Utc;
+
+    #[test]
+    fn policy_memory_is_cleared_on_reopen() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("state.db");
+
+        {
+            let store = Store::open(&path).unwrap();
+            store.with_conn(|c| {
+                c.execute(
+                    "INSERT INTO policy_memory (action_kind, target, allowed_at) VALUES (?1, ?2, ?3)",
+                    rusqlite::params!["delete_blob", "acme/x", Utc::now().to_rfc3339()],
+                ).map_err(|e| Error::Other(anyhow::anyhow!(e)))?;
+                Ok(())
+            }).unwrap();
+
+            let count: i64 = store.with_conn(|c| {
+                c.query_row("SELECT COUNT(*) FROM policy_memory", [], |r| r.get(0))
+                    .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+            }).unwrap();
+            assert_eq!(count, 1);
+        }
+
+        let store = Store::open(&path).unwrap();
+        let count: i64 = store.with_conn(|c| {
+            c.query_row("SELECT COUNT(*) FROM policy_memory", [], |r| r.get(0))
+                .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+        }).unwrap();
+        assert_eq!(count, 0, "policy_memory must be truncated on every open");
     }
 }

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -240,3 +240,6 @@ pub use storage_account::StorageAccount;
 
 pub mod attached_resource;
 pub use attached_resource::AttachedResource;
+
+pub mod context;
+pub use context::CurrentContext;

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -25,11 +25,13 @@ pub struct Store {
 impl Store {
     /// Open (or create) a store at the given path, applying migrations.
     pub fn open(path: &Path) -> Result<Self, Error> {
-        let conn = Connection::open(path)
-            .map_err(|e| Error::Other(anyhow::anyhow!("open store: {e}")))?;
+        let conn =
+            Connection::open(path).map_err(|e| Error::Other(anyhow::anyhow!("open store: {e}")))?;
         conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(|e| Error::Other(anyhow::anyhow!("enable foreign_keys: {e}")))?;
-        let store = Self { conn: Mutex::new(conn) };
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
         store.migrate()?;
         Ok(store)
     }
@@ -40,7 +42,9 @@ impl Store {
             .map_err(|e| Error::Other(anyhow::anyhow!("open in-memory store: {e}")))?;
         conn.pragma_update(None, "foreign_keys", "ON")
             .map_err(|e| Error::Other(anyhow::anyhow!("enable foreign_keys: {e}")))?;
-        let store = Self { conn: Mutex::new(conn) };
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
         store.migrate()?;
         Ok(store)
     }
@@ -54,13 +58,16 @@ impl Store {
                 value TEXT NOT NULL
             );
             "#,
-        ).map_err(|e| Error::Other(anyhow::anyhow!("migrate schema_meta: {e}")))?;
+        )
+        .map_err(|e| Error::Other(anyhow::anyhow!("migrate schema_meta: {e}")))?;
 
-        let current: Option<i32> = conn.query_row(
-            "SELECT value FROM schema_meta WHERE key = 'version'",
-            [],
-            |r| r.get::<_, String>(0).map(|s| s.parse::<i32>().unwrap_or(0)),
-        ).ok();
+        let current: Option<i32> = conn
+            .query_row(
+                "SELECT value FROM schema_meta WHERE key = 'version'",
+                [],
+                |r| r.get::<_, String>(0).map(|s| s.parse::<i32>().unwrap_or(0)),
+            )
+            .ok();
 
         if current.unwrap_or(0) < 1 {
             conn.execute_batch(MIGRATION_V1)
@@ -68,7 +75,8 @@ impl Store {
             conn.execute(
                 "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('version', ?1)",
                 rusqlite::params![SCHEMA_VERSION.to_string()],
-            ).map_err(|e| Error::Other(anyhow::anyhow!("record schema version: {e}")))?;
+            )
+            .map_err(|e| Error::Other(anyhow::anyhow!("record schema version: {e}")))?;
         }
 
         conn.execute("DELETE FROM policy_memory", [])
@@ -96,8 +104,10 @@ impl Store {
                     let s: String = r.get(0)?;
                     Ok(s.parse::<i32>().unwrap_or(0))
                 },
-            ).map_err(|e| Error::Other(anyhow::anyhow!("read schema version: {e}")))
-        }).unwrap_or(0)
+            )
+            .map_err(|e| Error::Other(anyhow::anyhow!("read schema version: {e}")))
+        })
+        .unwrap_or(0)
     }
 }
 
@@ -203,28 +213,34 @@ mod tests {
                 Ok(())
             }).unwrap();
 
-            let count: i64 = store.with_conn(|c| {
-                c.query_row("SELECT COUNT(*) FROM policy_memory", [], |r| r.get(0))
-                    .map_err(|e| Error::Other(anyhow::anyhow!(e)))
-            }).unwrap();
+            let count: i64 = store
+                .with_conn(|c| {
+                    c.query_row("SELECT COUNT(*) FROM policy_memory", [], |r| r.get(0))
+                        .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+                })
+                .unwrap();
             assert_eq!(count, 1);
         }
 
         let store = Store::open(&path).unwrap();
-        let count: i64 = store.with_conn(|c| {
-            c.query_row("SELECT COUNT(*) FROM policy_memory", [], |r| r.get(0))
-                .map_err(|e| Error::Other(anyhow::anyhow!(e)))
-        }).unwrap();
+        let count: i64 = store
+            .with_conn(|c| {
+                c.query_row("SELECT COUNT(*) FROM policy_memory", [], |r| r.get(0))
+                    .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+            })
+            .unwrap();
         assert_eq!(count, 0, "policy_memory must be truncated on every open");
     }
 
     #[test]
     fn foreign_keys_enforced_by_default() {
         let s = Store::open_in_memory().unwrap();
-        let enabled: i32 = s.with_conn(|c| {
-            c.query_row("PRAGMA foreign_keys", [], |r| r.get(0))
-                .map_err(|e| Error::Other(anyhow::anyhow!(e)))
-        }).unwrap();
+        let enabled: i32 = s
+            .with_conn(|c| {
+                c.query_row("PRAGMA foreign_keys", [], |r| r.get(0))
+                    .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+            })
+            .unwrap();
         assert_eq!(enabled, 1, "foreign_keys pragma must default to ON");
     }
 }

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -217,3 +217,6 @@ mod tests {
 
 pub mod sign_in;
 pub use sign_in::SignIn;
+
+pub mod subscription;
+pub use subscription::Subscription;

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -237,3 +237,6 @@ pub use subscription::Subscription;
 
 pub mod storage_account;
 pub use storage_account::StorageAccount;
+
+pub mod attached_resource;
+pub use attached_resource::AttachedResource;

--- a/crates/arkived-core/src/store/mod.rs
+++ b/crates/arkived-core/src/store/mod.rs
@@ -1,0 +1,181 @@
+//! SQLite-backed state store. Holds connection metadata (sign-ins,
+//! subscriptions, storage accounts, attached resources, current context,
+//! session policy memory). Holds **no credentials** — those live in the
+//! `CredentialStore` (OS keychain).
+//!
+//! Encryption-at-rest is a follow-up plan. v0.1.0 relies on OS file
+//! permissions for metadata (secrets are in keychain).
+
+use crate::Error;
+use rusqlite::Connection;
+use std::path::Path;
+use std::sync::Mutex;
+
+/// The schema version this build understands. Bumped on every migration.
+pub(crate) const SCHEMA_VERSION: i32 = 1;
+
+/// Handle to the SQLite-backed state store.
+///
+/// Cheap to clone via `Arc<Store>`. Internally guards the SQLite
+/// connection behind a `Mutex`; concurrent callers serialize on the lock.
+pub struct Store {
+    conn: Mutex<Connection>,
+}
+
+impl Store {
+    /// Open (or create) a store at the given path, applying migrations.
+    pub fn open(path: &Path) -> Result<Self, Error> {
+        let conn = Connection::open(path)
+            .map_err(|e| Error::Other(anyhow::anyhow!("open store: {e}")))?;
+        let store = Self { conn: Mutex::new(conn) };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    /// Open an in-memory store — useful for tests.
+    pub fn open_in_memory() -> Result<Self, Error> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| Error::Other(anyhow::anyhow!("open in-memory store: {e}")))?;
+        let store = Self { conn: Mutex::new(conn) };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    fn migrate(&self) -> Result<(), Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS schema_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            "#,
+        ).map_err(|e| Error::Other(anyhow::anyhow!("migrate schema_meta: {e}")))?;
+
+        let current: Option<i32> = conn.query_row(
+            "SELECT value FROM schema_meta WHERE key = 'version'",
+            [],
+            |r| r.get::<_, String>(0).map(|s| s.parse::<i32>().unwrap_or(0)),
+        ).ok();
+
+        if current.unwrap_or(0) < 1 {
+            conn.execute_batch(MIGRATION_V1)
+                .map_err(|e| Error::Other(anyhow::anyhow!("apply v1 migration: {e}")))?;
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('version', ?1)",
+                rusqlite::params![SCHEMA_VERSION.to_string()],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("record schema version: {e}")))?;
+        }
+
+        Ok(())
+    }
+
+    /// Access the underlying connection under a lock. Sub-modules use this.
+    pub(crate) fn with_conn<F, R>(&self, f: F) -> Result<R, Error>
+    where
+        F: FnOnce(&Connection) -> Result<R, Error>,
+    {
+        let guard = self.conn.lock().unwrap();
+        f(&guard)
+    }
+
+    /// Current schema version on disk (for diagnostics).
+    pub fn schema_version(&self) -> i32 {
+        self.with_conn(|c| {
+            c.query_row(
+                "SELECT value FROM schema_meta WHERE key = 'version'",
+                [],
+                |r| {
+                    let s: String = r.get(0)?;
+                    Ok(s.parse::<i32>().unwrap_or(0))
+                },
+            ).map_err(|e| Error::Other(anyhow::anyhow!("read schema version: {e}")))
+        }).unwrap_or(0)
+    }
+}
+
+/// v1 migration: create all foundation tables.
+const MIGRATION_V1: &str = r#"
+CREATE TABLE IF NOT EXISTS sign_in (
+    id            TEXT PRIMARY KEY,
+    display_name  TEXT NOT NULL,
+    tenant_id     TEXT NOT NULL,
+    environment   TEXT NOT NULL,
+    user_principal TEXT NOT NULL,
+    added_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subscription (
+    id            TEXT PRIMARY KEY,
+    sign_in_id    TEXT NOT NULL REFERENCES sign_in(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    tenant_id     TEXT NOT NULL,
+    discovered_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS storage_account (
+    name              TEXT PRIMARY KEY,
+    subscription_id   TEXT REFERENCES subscription(id) ON DELETE SET NULL,
+    kind              TEXT NOT NULL,
+    region            TEXT NOT NULL,
+    replication       TEXT NOT NULL,
+    tier              TEXT NOT NULL,
+    hns               INTEGER NOT NULL,
+    endpoint          TEXT NOT NULL,
+    attached_directly INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS attached_resource (
+    id            TEXT PRIMARY KEY,
+    display_name  TEXT NOT NULL,
+    resource_kind TEXT NOT NULL,
+    endpoint      TEXT NOT NULL,
+    auth_kind     TEXT NOT NULL,
+    keychain_ref  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS context (
+    k TEXT PRIMARY KEY,
+    v TEXT
+);
+
+CREATE TABLE IF NOT EXISTS policy_memory (
+    action_kind TEXT NOT NULL,
+    target      TEXT,
+    allowed_at  TEXT NOT NULL
+);
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn open_in_memory_applies_migrations() {
+        let store = Store::open_in_memory().unwrap();
+        assert_eq!(store.schema_version(), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn open_on_disk_persists_schema() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("state.db");
+
+        {
+            let store = Store::open(&path).unwrap();
+            assert_eq!(store.schema_version(), SCHEMA_VERSION);
+        }
+
+        let store = Store::open(&path).unwrap();
+        assert_eq!(store.schema_version(), SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let store = Store::open_in_memory().unwrap();
+        store.migrate().unwrap();
+        store.migrate().unwrap();
+        assert_eq!(store.schema_version(), SCHEMA_VERSION);
+    }
+}

--- a/crates/arkived-core/src/store/policy_memory.rs
+++ b/crates/arkived-core/src/store/policy_memory.rs
@@ -1,0 +1,108 @@
+//! Session-scoped allow-list used by `Policy` impls to remember
+//! "always allow X for this session" decisions. Truncated on Store::open.
+
+use crate::Error;
+use crate::store::Store;
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+
+/// An entry in the session-scope policy allow-list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyAllowEntry {
+    /// The action kind this allow covers (e.g. `"delete_blob"`).
+    pub action_kind: String,
+    /// The specific target this allow applies to, or `None` = any target.
+    pub target: Option<String>,
+    /// When the allow was recorded (this session).
+    pub allowed_at: DateTime<Utc>,
+}
+
+impl Store {
+    /// Record an allow for the given action kind. If `target` is `None`, the
+    /// allow applies to any target.
+    pub fn policy_memory_allow(&self, action_kind: &str, target: Option<&str>) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute(
+                "INSERT INTO policy_memory (action_kind, target, allowed_at) VALUES (?1, ?2, ?3)",
+                params![action_kind, target, Utc::now().to_rfc3339()],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory allow: {e}")))?;
+            Ok(())
+        })
+    }
+
+    /// Check whether an action is allowed for this session. Matches a prior
+    /// allow either with identical (action_kind, target) or with target = NULL.
+    pub fn policy_memory_is_allowed(&self, action_kind: &str, target: Option<&str>) -> Result<bool, Error> {
+        self.with_conn(|c| {
+            let count: i64 = c.query_row(
+                "SELECT COUNT(*) FROM policy_memory
+                 WHERE action_kind = ?1
+                   AND (target IS ?2 OR target IS NULL)",
+                params![action_kind, target],
+                |r| r.get(0),
+            ).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory check: {e}")))?;
+            Ok(count > 0)
+        })
+    }
+
+    /// List all session-scope allow entries in chronological order.
+    pub fn policy_memory_list(&self) -> Result<Vec<PolicyAllowEntry>, Error> {
+        self.with_conn(|c| {
+            let mut stmt = c.prepare(
+                "SELECT action_kind, target, allowed_at FROM policy_memory ORDER BY allowed_at"
+            ).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list prepare: {e}")))?;
+            let rows = stmt.query_map([], |row| {
+                let at: String = row.get(2)?;
+                Ok(PolicyAllowEntry {
+                    action_kind: row.get(0)?,
+                    target: row.get(1)?,
+                    allowed_at: DateTime::parse_from_rfc3339(&at)
+                        .map(|d| d.with_timezone(&Utc))
+                        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(
+                            2, rusqlite::types::Type::Text, Box::new(e),
+                        ))?,
+                })
+            }).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list query: {e}")))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list row: {e}")))?);
+            }
+            Ok(out)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::store::Store;
+
+    #[test]
+    fn allow_then_check_exact_target() {
+        let s = Store::open_in_memory().unwrap();
+        s.policy_memory_allow("delete_blob", Some("acmeprod")).unwrap();
+        assert!(s.policy_memory_is_allowed("delete_blob", Some("acmeprod")).unwrap());
+        assert!(!s.policy_memory_is_allowed("delete_blob", Some("other")).unwrap());
+        assert!(!s.policy_memory_is_allowed("set_tier", Some("acmeprod")).unwrap());
+    }
+
+    #[test]
+    fn any_target_allow_matches_everything() {
+        let s = Store::open_in_memory().unwrap();
+        s.policy_memory_allow("set_tier", None).unwrap();
+        assert!(s.policy_memory_is_allowed("set_tier", Some("a")).unwrap());
+        assert!(s.policy_memory_is_allowed("set_tier", Some("b")).unwrap());
+        assert!(s.policy_memory_is_allowed("set_tier", None).unwrap());
+    }
+
+    #[test]
+    fn list_returns_entries_in_order() {
+        let s = Store::open_in_memory().unwrap();
+        s.policy_memory_allow("delete_blob", Some("a")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        s.policy_memory_allow("set_tier", None).unwrap();
+        let list = s.policy_memory_list().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].action_kind, "delete_blob");
+        assert_eq!(list[1].action_kind, "set_tier");
+    }
+}

--- a/crates/arkived-core/src/store/policy_memory.rs
+++ b/crates/arkived-core/src/store/policy_memory.rs
@@ -1,8 +1,8 @@
 //! Session-scoped allow-list used by `Policy` impls to remember
 //! "always allow X for this session" decisions. Truncated on Store::open.
 
-use crate::Error;
 use crate::store::Store;
+use crate::Error;
 use chrono::{DateTime, Utc};
 use rusqlite::params;
 
@@ -20,27 +20,38 @@ pub struct PolicyAllowEntry {
 impl Store {
     /// Record an allow for the given action kind. If `target` is `None`, the
     /// allow applies to any target.
-    pub fn policy_memory_allow(&self, action_kind: &str, target: Option<&str>) -> Result<(), Error> {
+    pub fn policy_memory_allow(
+        &self,
+        action_kind: &str,
+        target: Option<&str>,
+    ) -> Result<(), Error> {
         self.with_conn(|c| {
             c.execute(
                 "INSERT INTO policy_memory (action_kind, target, allowed_at) VALUES (?1, ?2, ?3)",
                 params![action_kind, target, Utc::now().to_rfc3339()],
-            ).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory allow: {e}")))?;
+            )
+            .map_err(|e| Error::Other(anyhow::anyhow!("policy_memory allow: {e}")))?;
             Ok(())
         })
     }
 
     /// Check whether an action is allowed for this session. Matches a prior
     /// allow either with identical (action_kind, target) or with target = NULL.
-    pub fn policy_memory_is_allowed(&self, action_kind: &str, target: Option<&str>) -> Result<bool, Error> {
+    pub fn policy_memory_is_allowed(
+        &self,
+        action_kind: &str,
+        target: Option<&str>,
+    ) -> Result<bool, Error> {
         self.with_conn(|c| {
-            let count: i64 = c.query_row(
-                "SELECT COUNT(*) FROM policy_memory
+            let count: i64 = c
+                .query_row(
+                    "SELECT COUNT(*) FROM policy_memory
                  WHERE action_kind = ?1
                    AND (target IS ?2 OR target IS NULL)",
-                params![action_kind, target],
-                |r| r.get(0),
-            ).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory check: {e}")))?;
+                    params![action_kind, target],
+                    |r| r.get(0),
+                )
+                .map_err(|e| Error::Other(anyhow::anyhow!("policy_memory check: {e}")))?;
             Ok(count > 0)
         })
     }
@@ -48,24 +59,34 @@ impl Store {
     /// List all session-scope allow entries in chronological order.
     pub fn policy_memory_list(&self) -> Result<Vec<PolicyAllowEntry>, Error> {
         self.with_conn(|c| {
-            let mut stmt = c.prepare(
-                "SELECT action_kind, target, allowed_at FROM policy_memory ORDER BY allowed_at"
-            ).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list prepare: {e}")))?;
-            let rows = stmt.query_map([], |row| {
-                let at: String = row.get(2)?;
-                Ok(PolicyAllowEntry {
-                    action_kind: row.get(0)?,
-                    target: row.get(1)?,
-                    allowed_at: DateTime::parse_from_rfc3339(&at)
-                        .map(|d| d.with_timezone(&Utc))
-                        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(
-                            2, rusqlite::types::Type::Text, Box::new(e),
-                        ))?,
+            let mut stmt = c
+                .prepare(
+                    "SELECT action_kind, target, allowed_at FROM policy_memory ORDER BY allowed_at",
+                )
+                .map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list prepare: {e}")))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let at: String = row.get(2)?;
+                    Ok(PolicyAllowEntry {
+                        action_kind: row.get(0)?,
+                        target: row.get(1)?,
+                        allowed_at: DateTime::parse_from_rfc3339(&at)
+                            .map(|d| d.with_timezone(&Utc))
+                            .map_err(|e| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    2,
+                                    rusqlite::types::Type::Text,
+                                    Box::new(e),
+                                )
+                            })?,
+                    })
                 })
-            }).map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list query: {e}")))?;
+                .map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list query: {e}")))?;
             let mut out = Vec::new();
             for r in rows {
-                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list row: {e}")))?);
+                out.push(
+                    r.map_err(|e| Error::Other(anyhow::anyhow!("policy_memory list row: {e}")))?,
+                );
             }
             Ok(out)
         })
@@ -79,10 +100,17 @@ mod tests {
     #[test]
     fn allow_then_check_exact_target() {
         let s = Store::open_in_memory().unwrap();
-        s.policy_memory_allow("delete_blob", Some("acmeprod")).unwrap();
-        assert!(s.policy_memory_is_allowed("delete_blob", Some("acmeprod")).unwrap());
-        assert!(!s.policy_memory_is_allowed("delete_blob", Some("other")).unwrap());
-        assert!(!s.policy_memory_is_allowed("set_tier", Some("acmeprod")).unwrap());
+        s.policy_memory_allow("delete_blob", Some("acmeprod"))
+            .unwrap();
+        assert!(s
+            .policy_memory_is_allowed("delete_blob", Some("acmeprod"))
+            .unwrap());
+        assert!(!s
+            .policy_memory_is_allowed("delete_blob", Some("other"))
+            .unwrap());
+        assert!(!s
+            .policy_memory_is_allowed("set_tier", Some("acmeprod"))
+            .unwrap());
     }
 
     #[test]

--- a/crates/arkived-core/src/store/sign_in.rs
+++ b/crates/arkived-core/src/store/sign_in.rs
@@ -1,7 +1,7 @@
 //! CRUD for the `sign_in` table.
 
-use crate::Error;
 use crate::store::Store;
+use crate::Error;
 use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -44,19 +44,23 @@ impl Store {
                  FROM sign_in WHERE id = ?1",
                 params![id],
                 row_to_sign_in,
-            ).optional()
-             .map_err(|e| Error::Other(anyhow::anyhow!("sign_in get: {e}")))
+            )
+            .optional()
+            .map_err(|e| Error::Other(anyhow::anyhow!("sign_in get: {e}")))
         })
     }
 
     /// List all sign-ins ordered by `added_at` ascending.
     pub fn sign_in_list(&self) -> Result<Vec<SignIn>, Error> {
         self.with_conn(|c| {
-            let mut stmt = c.prepare(
-                "SELECT id, display_name, tenant_id, environment, user_principal, added_at
-                 FROM sign_in ORDER BY added_at"
-            ).map_err(|e| Error::Other(anyhow::anyhow!("sign_in list prepare: {e}")))?;
-            let rows = stmt.query_map([], row_to_sign_in)
+            let mut stmt = c
+                .prepare(
+                    "SELECT id, display_name, tenant_id, environment, user_principal, added_at
+                 FROM sign_in ORDER BY added_at",
+                )
+                .map_err(|e| Error::Other(anyhow::anyhow!("sign_in list prepare: {e}")))?;
+            let rows = stmt
+                .query_map([], row_to_sign_in)
                 .map_err(|e| Error::Other(anyhow::anyhow!("sign_in list query: {e}")))?;
             let mut out = Vec::new();
             for r in rows {
@@ -86,7 +90,13 @@ fn row_to_sign_in(row: &rusqlite::Row<'_>) -> rusqlite::Result<SignIn> {
         user_principal: row.get(4)?,
         added_at: DateTime::parse_from_rfc3339(&added_at)
             .map(|d| d.with_timezone(&Utc))
-            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(e)))?,
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    5,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?,
     })
 }
 

--- a/crates/arkived-core/src/store/sign_in.rs
+++ b/crates/arkived-core/src/store/sign_in.rs
@@ -1,0 +1,145 @@
+//! CRUD for the `sign_in` table.
+
+use crate::Error;
+use crate::store::Store;
+use chrono::{DateTime, Utc};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// A persisted Microsoft Entra sign-in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignIn {
+    /// Opaque stable identifier (caller-chosen — typically a UUID).
+    pub id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Entra tenant ID associated with this sign-in.
+    pub tenant_id: String,
+    /// Azure environment (`"azure"`, `"china"`, `"usgov"`, …).
+    pub environment: String,
+    /// Signed-in user principal (e.g. `hamza@example.com`).
+    pub user_principal: String,
+    /// When this sign-in was added to the store (UTC).
+    pub added_at: DateTime<Utc>,
+}
+
+impl Store {
+    /// Insert a new sign-in. Fails on duplicate `id`.
+    pub fn sign_in_insert(&self, s: &SignIn) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute(
+                "INSERT INTO sign_in (id, display_name, tenant_id, environment, user_principal, added_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![s.id, s.display_name, s.tenant_id, s.environment, s.user_principal, s.added_at.to_rfc3339()],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("sign_in insert: {e}")))?;
+            Ok(())
+        })
+    }
+
+    /// Fetch a sign-in by id. Returns `Ok(None)` if not found.
+    pub fn sign_in_get(&self, id: &str) -> Result<Option<SignIn>, Error> {
+        self.with_conn(|c| {
+            c.query_row(
+                "SELECT id, display_name, tenant_id, environment, user_principal, added_at
+                 FROM sign_in WHERE id = ?1",
+                params![id],
+                row_to_sign_in,
+            ).optional()
+             .map_err(|e| Error::Other(anyhow::anyhow!("sign_in get: {e}")))
+        })
+    }
+
+    /// List all sign-ins ordered by `added_at` ascending.
+    pub fn sign_in_list(&self) -> Result<Vec<SignIn>, Error> {
+        self.with_conn(|c| {
+            let mut stmt = c.prepare(
+                "SELECT id, display_name, tenant_id, environment, user_principal, added_at
+                 FROM sign_in ORDER BY added_at"
+            ).map_err(|e| Error::Other(anyhow::anyhow!("sign_in list prepare: {e}")))?;
+            let rows = stmt.query_map([], row_to_sign_in)
+                .map_err(|e| Error::Other(anyhow::anyhow!("sign_in list query: {e}")))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("sign_in list row: {e}")))?);
+            }
+            Ok(out)
+        })
+    }
+
+    /// Delete a sign-in by id. Cascades to subscriptions via FK.
+    pub fn sign_in_delete(&self, id: &str) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute("DELETE FROM sign_in WHERE id = ?1", params![id])
+                .map_err(|e| Error::Other(anyhow::anyhow!("sign_in delete: {e}")))?;
+            Ok(())
+        })
+    }
+}
+
+fn row_to_sign_in(row: &rusqlite::Row<'_>) -> rusqlite::Result<SignIn> {
+    let added_at: String = row.get(5)?;
+    Ok(SignIn {
+        id: row.get(0)?,
+        display_name: row.get(1)?,
+        tenant_id: row.get(2)?,
+        environment: row.get(3)?,
+        user_principal: row.get(4)?,
+        added_at: DateTime::parse_from_rfc3339(&added_at)
+            .map(|d| d.with_timezone(&Utc))
+            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(e)))?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Store;
+
+    fn sample() -> SignIn {
+        SignIn {
+            id: "sign-1".into(),
+            display_name: "Hamza".into(),
+            tenant_id: "tenant-abc".into(),
+            environment: "azure".into(),
+            user_principal: "hamza@horizon-tech.io".into(),
+            added_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn insert_get_roundtrip() {
+        let s = Store::open_in_memory().unwrap();
+        let a = sample();
+        s.sign_in_insert(&a).unwrap();
+        let got = s.sign_in_get(&a.id).unwrap().unwrap();
+        assert_eq!(got.id, a.id);
+        assert_eq!(got.display_name, a.display_name);
+        assert_eq!(got.tenant_id, a.tenant_id);
+    }
+
+    #[test]
+    fn get_missing_is_none() {
+        let s = Store::open_in_memory().unwrap();
+        assert!(s.sign_in_get("nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_and_delete() {
+        let s = Store::open_in_memory().unwrap();
+        let a = sample();
+        let mut b = sample();
+        b.id = "sign-2".into();
+        b.user_principal = "other@horizon-tech.io".into();
+        b.added_at = a.added_at + chrono::Duration::seconds(1);
+
+        s.sign_in_insert(&a).unwrap();
+        s.sign_in_insert(&b).unwrap();
+        let list = s.sign_in_list().unwrap();
+        assert_eq!(list.len(), 2);
+
+        s.sign_in_delete(&a.id).unwrap();
+        let list = s.sign_in_list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "sign-2");
+    }
+}

--- a/crates/arkived-core/src/store/storage_account.rs
+++ b/crates/arkived-core/src/store/storage_account.rs
@@ -1,7 +1,7 @@
 //! CRUD for the `storage_account` table.
 
-use crate::Error;
 use crate::store::Store;
+use crate::Error;
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
@@ -68,7 +68,10 @@ impl Store {
     }
 
     /// List all storage accounts under a subscription, ordered by name.
-    pub fn storage_account_list_for_subscription(&self, subscription_id: &str) -> Result<Vec<StorageAccount>, Error> {
+    pub fn storage_account_list_for_subscription(
+        &self,
+        subscription_id: &str,
+    ) -> Result<Vec<StorageAccount>, Error> {
         self.with_conn(|c| {
             let mut stmt = c.prepare(
                 "SELECT name, subscription_id, kind, region, replication, tier, hns, endpoint, attached_directly
@@ -128,25 +131,29 @@ fn row_to_account(row: &rusqlite::Row<'_>) -> rusqlite::Result<StorageAccount> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::{Store, SignIn, Subscription};
+    use crate::store::{SignIn, Store, Subscription};
     use chrono::Utc;
 
     fn seed(store: &Store) {
-        store.sign_in_insert(&SignIn {
-            id: "si-1".into(),
-            display_name: "Hamza".into(),
-            tenant_id: "t".into(),
-            environment: "azure".into(),
-            user_principal: "h@x".into(),
-            added_at: Utc::now(),
-        }).unwrap();
-        store.subscription_upsert(&Subscription {
-            id: "sub-1".into(),
-            sign_in_id: "si-1".into(),
-            name: "dev".into(),
-            tenant_id: "t".into(),
-            discovered_at: Utc::now(),
-        }).unwrap();
+        store
+            .sign_in_insert(&SignIn {
+                id: "si-1".into(),
+                display_name: "Hamza".into(),
+                tenant_id: "t".into(),
+                environment: "azure".into(),
+                user_principal: "h@x".into(),
+                added_at: Utc::now(),
+            })
+            .unwrap();
+        store
+            .subscription_upsert(&Subscription {
+                id: "sub-1".into(),
+                sign_in_id: "si-1".into(),
+                name: "dev".into(),
+                tenant_id: "t".into(),
+                discovered_at: Utc::now(),
+            })
+            .unwrap();
     }
 
     fn account(name: &str) -> StorageAccount {

--- a/crates/arkived-core/src/store/storage_account.rs
+++ b/crates/arkived-core/src/store/storage_account.rs
@@ -1,0 +1,209 @@
+//! CRUD for the `storage_account` table.
+
+use crate::Error;
+use crate::store::Store;
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// An Azure storage account — either discovered under a subscription or
+/// directly attached via SAS/connection-string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageAccount {
+    /// Azure-unique storage account name.
+    pub name: String,
+    /// Owning subscription, or `None` if attached directly (not inside a sign-in).
+    pub subscription_id: Option<String>,
+    /// SKU kind (`StorageV2`, `StorageV2 (ADLS Gen2)`, …).
+    pub kind: String,
+    /// Azure region.
+    pub region: String,
+    /// Replication strategy (`LRS`, `GRS`, `ZRS`, `RA-GZRS`).
+    pub replication: String,
+    /// Performance tier (`Standard` or `Premium`).
+    pub tier: String,
+    /// Whether hierarchical namespace (ADLS Gen2) is enabled.
+    pub hns: bool,
+    /// Blob endpoint URL.
+    pub endpoint: String,
+    /// Whether this account was attached directly (outside a sign-in) via SAS/key.
+    pub attached_directly: bool,
+}
+
+impl Store {
+    /// Insert or update a storage account (upsert on `name`).
+    pub fn storage_account_upsert(&self, a: &StorageAccount) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute(
+                "INSERT INTO storage_account
+                   (name, subscription_id, kind, region, replication, tier, hns, endpoint, attached_directly)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(name) DO UPDATE SET
+                   subscription_id = excluded.subscription_id,
+                   kind = excluded.kind,
+                   region = excluded.region,
+                   replication = excluded.replication,
+                   tier = excluded.tier,
+                   hns = excluded.hns,
+                   endpoint = excluded.endpoint,
+                   attached_directly = excluded.attached_directly",
+                params![
+                    a.name, a.subscription_id, a.kind, a.region, a.replication,
+                    a.tier, a.hns as i32, a.endpoint, a.attached_directly as i32,
+                ],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("storage_account upsert: {e}")))?;
+            Ok(())
+        })
+    }
+
+    /// Fetch a storage account by name. Returns `Ok(None)` if not found.
+    pub fn storage_account_get(&self, name: &str) -> Result<Option<StorageAccount>, Error> {
+        self.with_conn(|c| {
+            c.query_row(
+                "SELECT name, subscription_id, kind, region, replication, tier, hns, endpoint, attached_directly
+                 FROM storage_account WHERE name = ?1",
+                params![name],
+                row_to_account,
+            ).optional().map_err(|e| Error::Other(anyhow::anyhow!("storage_account get: {e}")))
+        })
+    }
+
+    /// List all storage accounts under a subscription, ordered by name.
+    pub fn storage_account_list_for_subscription(&self, subscription_id: &str) -> Result<Vec<StorageAccount>, Error> {
+        self.with_conn(|c| {
+            let mut stmt = c.prepare(
+                "SELECT name, subscription_id, kind, region, replication, tier, hns, endpoint, attached_directly
+                 FROM storage_account WHERE subscription_id = ?1 ORDER BY name"
+            ).map_err(|e| Error::Other(anyhow::anyhow!("storage_account list prepare: {e}")))?;
+            let rows = stmt.query_map(params![subscription_id], row_to_account)
+                .map_err(|e| Error::Other(anyhow::anyhow!("storage_account list query: {e}")))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("storage_account list row: {e}")))?);
+            }
+            Ok(out)
+        })
+    }
+
+    /// List all storage accounts attached directly (outside any sign-in).
+    pub fn storage_account_list_attached_directly(&self) -> Result<Vec<StorageAccount>, Error> {
+        self.with_conn(|c| {
+            let mut stmt = c.prepare(
+                "SELECT name, subscription_id, kind, region, replication, tier, hns, endpoint, attached_directly
+                 FROM storage_account WHERE attached_directly = 1 ORDER BY name"
+            ).map_err(|e| Error::Other(anyhow::anyhow!("storage_account list_attached prepare: {e}")))?;
+            let rows = stmt.query_map([], row_to_account)
+                .map_err(|e| Error::Other(anyhow::anyhow!("storage_account list_attached query: {e}")))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("storage_account list_attached row: {e}")))?);
+            }
+            Ok(out)
+        })
+    }
+
+    /// Delete a storage account by name.
+    pub fn storage_account_delete(&self, name: &str) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute("DELETE FROM storage_account WHERE name = ?1", params![name])
+                .map_err(|e| Error::Other(anyhow::anyhow!("storage_account delete: {e}")))?;
+            Ok(())
+        })
+    }
+}
+
+fn row_to_account(row: &rusqlite::Row<'_>) -> rusqlite::Result<StorageAccount> {
+    Ok(StorageAccount {
+        name: row.get(0)?,
+        subscription_id: row.get(1)?,
+        kind: row.get(2)?,
+        region: row.get(3)?,
+        replication: row.get(4)?,
+        tier: row.get(5)?,
+        hns: row.get::<_, i32>(6)? != 0,
+        endpoint: row.get(7)?,
+        attached_directly: row.get::<_, i32>(8)? != 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::{Store, SignIn, Subscription};
+    use chrono::Utc;
+
+    fn seed(store: &Store) {
+        store.sign_in_insert(&SignIn {
+            id: "si-1".into(),
+            display_name: "Hamza".into(),
+            tenant_id: "t".into(),
+            environment: "azure".into(),
+            user_principal: "h@x".into(),
+            added_at: Utc::now(),
+        }).unwrap();
+        store.subscription_upsert(&Subscription {
+            id: "sub-1".into(),
+            sign_in_id: "si-1".into(),
+            name: "dev".into(),
+            tenant_id: "t".into(),
+            discovered_at: Utc::now(),
+        }).unwrap();
+    }
+
+    fn account(name: &str) -> StorageAccount {
+        StorageAccount {
+            name: name.into(),
+            subscription_id: Some("sub-1".into()),
+            kind: "StorageV2 (ADLS Gen2)".into(),
+            region: "West Europe".into(),
+            replication: "LRS".into(),
+            tier: "Premium".into(),
+            hns: true,
+            endpoint: format!("https://{name}.blob.core.windows.net"),
+            attached_directly: false,
+        }
+    }
+
+    #[test]
+    fn upsert_get_and_hns_bool_roundtrip() {
+        let s = Store::open_in_memory().unwrap();
+        seed(&s);
+        s.storage_account_upsert(&account("acmeprod")).unwrap();
+        let got = s.storage_account_get("acmeprod").unwrap().unwrap();
+        assert!(got.hns);
+        assert!(!got.attached_directly);
+    }
+
+    #[test]
+    fn list_for_subscription() {
+        let s = Store::open_in_memory().unwrap();
+        seed(&s);
+        s.storage_account_upsert(&account("acmea")).unwrap();
+        s.storage_account_upsert(&account("acmeb")).unwrap();
+        let list = s.storage_account_list_for_subscription("sub-1").unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn list_attached_directly_only() {
+        let s = Store::open_in_memory().unwrap();
+        seed(&s);
+        let normal = account("acmeprod");
+        let mut attached = account("attached");
+        attached.subscription_id = None;
+        attached.attached_directly = true;
+        s.storage_account_upsert(&normal).unwrap();
+        s.storage_account_upsert(&attached).unwrap();
+        let list = s.storage_account_list_attached_directly().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "attached");
+    }
+
+    #[test]
+    fn delete() {
+        let s = Store::open_in_memory().unwrap();
+        seed(&s);
+        s.storage_account_upsert(&account("acmeprod")).unwrap();
+        s.storage_account_delete("acmeprod").unwrap();
+        assert!(s.storage_account_get("acmeprod").unwrap().is_none());
+    }
+}

--- a/crates/arkived-core/src/store/subscription.rs
+++ b/crates/arkived-core/src/store/subscription.rs
@@ -169,12 +169,6 @@ mod tests {
         let s = Store::open_in_memory().unwrap();
         s.sign_in_insert(&parent_sign_in()).unwrap();
         s.subscription_upsert(&child_sub()).unwrap();
-        // Enable FK pragma locally for this test (Task 14 will make it default).
-        s.with_conn(|c| {
-            c.pragma_update(None, "foreign_keys", "ON")
-                .map_err(|e| Error::Other(anyhow::anyhow!(e)))
-        })
-        .unwrap();
         s.sign_in_delete("si-1").unwrap();
         assert!(s.subscription_get("sub-1").unwrap().is_none());
     }

--- a/crates/arkived-core/src/store/subscription.rs
+++ b/crates/arkived-core/src/store/subscription.rs
@@ -1,7 +1,7 @@
 //! CRUD for the `subscription` table.
 
-use crate::Error;
 use crate::store::Store;
+use crate::Error;
 use chrono::{DateTime, Utc};
 use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -33,8 +33,15 @@ impl Store {
                     name = excluded.name,
                     tenant_id = excluded.tenant_id,
                     discovered_at = excluded.discovered_at",
-                params![s.id, s.sign_in_id, s.name, s.tenant_id, s.discovered_at.to_rfc3339()],
-            ).map_err(|e| Error::Other(anyhow::anyhow!("subscription upsert: {e}")))?;
+                params![
+                    s.id,
+                    s.sign_in_id,
+                    s.name,
+                    s.tenant_id,
+                    s.discovered_at.to_rfc3339()
+                ],
+            )
+            .map_err(|e| Error::Other(anyhow::anyhow!("subscription upsert: {e}")))?;
             Ok(())
         })
     }
@@ -51,17 +58,25 @@ impl Store {
     }
 
     /// List all subscriptions under a specific sign-in, ordered by name.
-    pub fn subscription_list_for_sign_in(&self, sign_in_id: &str) -> Result<Vec<Subscription>, Error> {
+    pub fn subscription_list_for_sign_in(
+        &self,
+        sign_in_id: &str,
+    ) -> Result<Vec<Subscription>, Error> {
         self.with_conn(|c| {
-            let mut stmt = c.prepare(
-                "SELECT id, sign_in_id, name, tenant_id, discovered_at FROM subscription
-                 WHERE sign_in_id = ?1 ORDER BY name"
-            ).map_err(|e| Error::Other(anyhow::anyhow!("subscription list prepare: {e}")))?;
-            let rows = stmt.query_map(params![sign_in_id], row_to_sub)
+            let mut stmt = c
+                .prepare(
+                    "SELECT id, sign_in_id, name, tenant_id, discovered_at FROM subscription
+                 WHERE sign_in_id = ?1 ORDER BY name",
+                )
+                .map_err(|e| Error::Other(anyhow::anyhow!("subscription list prepare: {e}")))?;
+            let rows = stmt
+                .query_map(params![sign_in_id], row_to_sub)
                 .map_err(|e| Error::Other(anyhow::anyhow!("subscription list query: {e}")))?;
             let mut out = Vec::new();
             for r in rows {
-                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("subscription list row: {e}")))?);
+                out.push(
+                    r.map_err(|e| Error::Other(anyhow::anyhow!("subscription list row: {e}")))?,
+                );
             }
             Ok(out)
         })
@@ -77,14 +92,20 @@ fn row_to_sub(row: &rusqlite::Row<'_>) -> rusqlite::Result<Subscription> {
         tenant_id: row.get(3)?,
         discovered_at: DateTime::parse_from_rfc3339(&discovered_at)
             .map(|d| d.with_timezone(&Utc))
-            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e)))?,
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    4,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::{Store, SignIn};
+    use crate::store::{SignIn, Store};
 
     fn parent_sign_in() -> SignIn {
         SignIn {
@@ -149,7 +170,11 @@ mod tests {
         s.sign_in_insert(&parent_sign_in()).unwrap();
         s.subscription_upsert(&child_sub()).unwrap();
         // Enable FK pragma locally for this test (Task 14 will make it default).
-        s.with_conn(|c| { c.pragma_update(None, "foreign_keys", "ON").map_err(|e| Error::Other(anyhow::anyhow!(e))) }).unwrap();
+        s.with_conn(|c| {
+            c.pragma_update(None, "foreign_keys", "ON")
+                .map_err(|e| Error::Other(anyhow::anyhow!(e)))
+        })
+        .unwrap();
         s.sign_in_delete("si-1").unwrap();
         assert!(s.subscription_get("sub-1").unwrap().is_none());
     }

--- a/crates/arkived-core/src/store/subscription.rs
+++ b/crates/arkived-core/src/store/subscription.rs
@@ -1,0 +1,156 @@
+//! CRUD for the `subscription` table.
+
+use crate::Error;
+use crate::store::Store;
+use chrono::{DateTime, Utc};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// An Azure subscription discovered under a sign-in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Subscription {
+    /// Azure subscription ID (UUID-shaped).
+    pub id: String,
+    /// Foreign key to the owning `sign_in.id`.
+    pub sign_in_id: String,
+    /// Display name of the subscription.
+    pub name: String,
+    /// Tenant ID the subscription resides in.
+    pub tenant_id: String,
+    /// When this subscription was discovered/refreshed (UTC).
+    pub discovered_at: DateTime<Utc>,
+}
+
+impl Store {
+    /// Insert or update a subscription (upsert on `id`).
+    pub fn subscription_upsert(&self, s: &Subscription) -> Result<(), Error> {
+        self.with_conn(|c| {
+            c.execute(
+                "INSERT INTO subscription (id, sign_in_id, name, tenant_id, discovered_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(id) DO UPDATE SET
+                    sign_in_id = excluded.sign_in_id,
+                    name = excluded.name,
+                    tenant_id = excluded.tenant_id,
+                    discovered_at = excluded.discovered_at",
+                params![s.id, s.sign_in_id, s.name, s.tenant_id, s.discovered_at.to_rfc3339()],
+            ).map_err(|e| Error::Other(anyhow::anyhow!("subscription upsert: {e}")))?;
+            Ok(())
+        })
+    }
+
+    /// Fetch a subscription by id. Returns `Ok(None)` if not found.
+    pub fn subscription_get(&self, id: &str) -> Result<Option<Subscription>, Error> {
+        self.with_conn(|c| {
+            c.query_row(
+                "SELECT id, sign_in_id, name, tenant_id, discovered_at FROM subscription WHERE id = ?1",
+                params![id],
+                row_to_sub,
+            ).optional().map_err(|e| Error::Other(anyhow::anyhow!("subscription get: {e}")))
+        })
+    }
+
+    /// List all subscriptions under a specific sign-in, ordered by name.
+    pub fn subscription_list_for_sign_in(&self, sign_in_id: &str) -> Result<Vec<Subscription>, Error> {
+        self.with_conn(|c| {
+            let mut stmt = c.prepare(
+                "SELECT id, sign_in_id, name, tenant_id, discovered_at FROM subscription
+                 WHERE sign_in_id = ?1 ORDER BY name"
+            ).map_err(|e| Error::Other(anyhow::anyhow!("subscription list prepare: {e}")))?;
+            let rows = stmt.query_map(params![sign_in_id], row_to_sub)
+                .map_err(|e| Error::Other(anyhow::anyhow!("subscription list query: {e}")))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| Error::Other(anyhow::anyhow!("subscription list row: {e}")))?);
+            }
+            Ok(out)
+        })
+    }
+}
+
+fn row_to_sub(row: &rusqlite::Row<'_>) -> rusqlite::Result<Subscription> {
+    let discovered_at: String = row.get(4)?;
+    Ok(Subscription {
+        id: row.get(0)?,
+        sign_in_id: row.get(1)?,
+        name: row.get(2)?,
+        tenant_id: row.get(3)?,
+        discovered_at: DateTime::parse_from_rfc3339(&discovered_at)
+            .map(|d| d.with_timezone(&Utc))
+            .map_err(|e| rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(e)))?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::{Store, SignIn};
+
+    fn parent_sign_in() -> SignIn {
+        SignIn {
+            id: "si-1".into(),
+            display_name: "Hamza".into(),
+            tenant_id: "tenant-abc".into(),
+            environment: "azure".into(),
+            user_principal: "h@x".into(),
+            added_at: Utc::now(),
+        }
+    }
+
+    fn child_sub() -> Subscription {
+        Subscription {
+            id: "sub-1".into(),
+            sign_in_id: "si-1".into(),
+            name: "dev".into(),
+            tenant_id: "tenant-abc".into(),
+            discovered_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn upsert_get_roundtrip() {
+        let s = Store::open_in_memory().unwrap();
+        s.sign_in_insert(&parent_sign_in()).unwrap();
+        s.subscription_upsert(&child_sub()).unwrap();
+        let got = s.subscription_get("sub-1").unwrap().unwrap();
+        assert_eq!(got.name, "dev");
+    }
+
+    #[test]
+    fn upsert_updates_existing() {
+        let s = Store::open_in_memory().unwrap();
+        s.sign_in_insert(&parent_sign_in()).unwrap();
+        let mut first = child_sub();
+        s.subscription_upsert(&first).unwrap();
+        first.name = "prod".into();
+        s.subscription_upsert(&first).unwrap();
+        assert_eq!(s.subscription_get("sub-1").unwrap().unwrap().name, "prod");
+    }
+
+    #[test]
+    fn list_for_sign_in() {
+        let s = Store::open_in_memory().unwrap();
+        s.sign_in_insert(&parent_sign_in()).unwrap();
+        let a = child_sub();
+        let mut b = child_sub();
+        b.id = "sub-2".into();
+        b.name = "prod".into();
+        s.subscription_upsert(&a).unwrap();
+        s.subscription_upsert(&b).unwrap();
+        let subs = s.subscription_list_for_sign_in("si-1").unwrap();
+        assert_eq!(subs.len(), 2);
+        let names: Vec<_> = subs.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["dev", "prod"]);
+    }
+
+    #[test]
+    fn cascade_delete_from_sign_in() {
+        let s = Store::open_in_memory().unwrap();
+        s.sign_in_insert(&parent_sign_in()).unwrap();
+        s.subscription_upsert(&child_sub()).unwrap();
+        // Enable FK pragma locally for this test (Task 14 will make it default).
+        s.with_conn(|c| { c.pragma_update(None, "foreign_keys", "ON").map_err(|e| Error::Other(anyhow::anyhow!(e))) }).unwrap();
+        s.sign_in_delete("si-1").unwrap();
+        assert!(s.subscription_get("sub-1").unwrap().is_none());
+    }
+}

--- a/crates/arkived-core/src/types.rs
+++ b/crates/arkived-core/src/types.rs
@@ -1,0 +1,114 @@
+//! Shared enums used across subsystems.
+
+use serde::{Deserialize, Serialize};
+
+/// Azure storage resource categories — used by `AuthProvider::supports`
+/// and the attach flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResourceKind {
+    /// The entire storage account.
+    StorageAccount,
+    /// A blob container.
+    BlobContainer,
+    /// An ADLS Gen2 container (hierarchical namespace).
+    AdlsContainer,
+    /// A directory inside an ADLS Gen2 container.
+    AdlsDirectory,
+    /// An Azure Files SMB file share.
+    FileShare,
+    /// An Azure Queue.
+    Queue,
+    /// An Azure Table.
+    Table,
+}
+
+/// Classification of an `AuthProvider` — informs UI and CLI output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthKind {
+    /// Microsoft Entra ID via interactive browser.
+    EntraInteractive,
+    /// Microsoft Entra ID via device code flow.
+    EntraDeviceCode,
+    /// Storage account shared key.
+    AccountKey,
+    /// Full Azure Storage connection string.
+    ConnectionString,
+    /// Shared access signature (URL or token).
+    SasToken,
+    /// Anonymous (no credential; public containers only).
+    Anonymous,
+    /// Entra service principal (client_id + client_secret).
+    ServicePrincipal,
+    /// Managed identity (for Azure-hosted runtimes).
+    ManagedIdentity,
+    /// Workload identity (federated credentials).
+    WorkloadIdentity,
+    /// The local Azurite emulator's well-known dev credentials.
+    AzuriteEmulator,
+}
+
+/// Azure cloud environment. Stored per-connection so one install can talk
+/// to multiple clouds simultaneously.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AzureEnvironment {
+    /// Public Azure (`core.windows.net`).
+    Public,
+    /// Azure China operated by 21Vianet (`core.chinacloudapi.cn`).
+    China,
+    /// Azure US Government (`core.usgovcloudapi.net`).
+    UsGov,
+    /// Azure Germany (`core.cloudapi.de`).
+    Germany,
+    /// Custom / sovereign / on-prem environment.
+    Custom {
+        /// Active Directory (Entra) endpoint URL.
+        active_directory_url: String,
+        /// DNS suffix for storage endpoints.
+        storage_suffix: String,
+    },
+}
+
+impl AzureEnvironment {
+    /// Return the storage DNS suffix for this environment.
+    pub fn storage_suffix(&self) -> &str {
+        match self {
+            Self::Public  => "core.windows.net",
+            Self::China   => "core.chinacloudapi.cn",
+            Self::UsGov   => "core.usgovcloudapi.net",
+            Self::Germany => "core.cloudapi.de",
+            Self::Custom { storage_suffix, .. } => storage_suffix,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_suffixes() {
+        assert_eq!(AzureEnvironment::Public.storage_suffix(), "core.windows.net");
+        assert_eq!(AzureEnvironment::China.storage_suffix(), "core.chinacloudapi.cn");
+    }
+
+    #[test]
+    fn custom_suffix_passthrough() {
+        let env = AzureEnvironment::Custom {
+            active_directory_url: "https://ad.example".into(),
+            storage_suffix: "blob.example.com".into(),
+        };
+        assert_eq!(env.storage_suffix(), "blob.example.com");
+    }
+
+    #[test]
+    fn resource_kind_serde() {
+        let r = ResourceKind::BlobContainer;
+        let s = serde_json::to_string(&r).unwrap();
+        assert_eq!(s, r#""blob-container""#);
+        let back: ResourceKind = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, r);
+    }
+}

--- a/crates/arkived-core/src/types.rs
+++ b/crates/arkived-core/src/types.rs
@@ -75,9 +75,9 @@ impl AzureEnvironment {
     /// Return the storage DNS suffix for this environment.
     pub fn storage_suffix(&self) -> &str {
         match self {
-            Self::Public  => "core.windows.net",
-            Self::China   => "core.chinacloudapi.cn",
-            Self::UsGov   => "core.usgovcloudapi.net",
+            Self::Public => "core.windows.net",
+            Self::China => "core.chinacloudapi.cn",
+            Self::UsGov => "core.usgovcloudapi.net",
             Self::Germany => "core.cloudapi.de",
             Self::Custom { storage_suffix, .. } => storage_suffix,
         }
@@ -90,8 +90,14 @@ mod tests {
 
     #[test]
     fn known_suffixes() {
-        assert_eq!(AzureEnvironment::Public.storage_suffix(), "core.windows.net");
-        assert_eq!(AzureEnvironment::China.storage_suffix(), "core.chinacloudapi.cn");
+        assert_eq!(
+            AzureEnvironment::Public.storage_suffix(),
+            "core.windows.net"
+        );
+        assert_eq!(
+            AzureEnvironment::China.storage_suffix(),
+            "core.chinacloudapi.cn"
+        );
     }
 
     #[test]

--- a/crates/arkived-core/tests/foundation_integration.rs
+++ b/crates/arkived-core/tests/foundation_integration.rs
@@ -2,7 +2,9 @@
 //!
 //! This test exercises the realistic flow a CLI `login` + `context use` would trigger.
 
-use arkived_core::store::{Store, SignIn, Subscription, StorageAccount, AttachedResource, CurrentContext, PolicyAllowEntry};
+use arkived_core::store::{
+    AttachedResource, CurrentContext, PolicyAllowEntry, SignIn, StorageAccount, Store, Subscription,
+};
 use arkived_core::types::{AuthKind, ResourceKind};
 use chrono::Utc;
 use tempfile::tempdir;
@@ -17,63 +19,88 @@ fn full_flow_add_signin_discover_pick_context_policy_memory() {
         let store = Store::open(&db).unwrap();
 
         // 1. User signs in
-        store.sign_in_insert(&SignIn {
-            id: "si-hamza".into(),
-            display_name: "Hamza Abdagić".into(),
-            tenant_id: "tenant-abc".into(),
-            environment: "azure".into(),
-            user_principal: "hamza@horizon-tech.io".into(),
-            added_at: Utc::now(),
-        }).unwrap();
+        store
+            .sign_in_insert(&SignIn {
+                id: "si-hamza".into(),
+                display_name: "Hamza Abdagić".into(),
+                tenant_id: "tenant-abc".into(),
+                environment: "azure".into(),
+                user_principal: "hamza@horizon-tech.io".into(),
+                added_at: Utc::now(),
+            })
+            .unwrap();
 
         // 2. Discovery finds two subscriptions
-        for (id, name) in [("sub-dev", "din — development"), ("sub-prod", "Horizon Tech — Prod")] {
-            store.subscription_upsert(&Subscription {
-                id: id.into(),
-                sign_in_id: "si-hamza".into(),
-                name: name.into(),
-                tenant_id: "tenant-abc".into(),
-                discovered_at: Utc::now(),
-            }).unwrap();
+        for (id, name) in [
+            ("sub-dev", "din — development"),
+            ("sub-prod", "Horizon Tech — Prod"),
+        ] {
+            store
+                .subscription_upsert(&Subscription {
+                    id: id.into(),
+                    sign_in_id: "si-hamza".into(),
+                    name: name.into(),
+                    tenant_id: "tenant-abc".into(),
+                    discovered_at: Utc::now(),
+                })
+                .unwrap();
         }
 
         // 3. Discovery finds storage accounts under `sub-dev`
         for name in ["stdlnphoenixproddlp", "stdlnphoenixdevfunc"] {
-            store.storage_account_upsert(&StorageAccount {
-                name: name.into(),
-                subscription_id: Some("sub-dev".into()),
-                kind: "StorageV2 (ADLS Gen2)".into(),
-                region: "West Europe".into(),
-                replication: "LRS".into(),
-                tier: "Premium".into(),
-                hns: name.ends_with("proddlp"),
-                endpoint: format!("https://{name}.blob.core.windows.net"),
-                attached_directly: false,
-            }).unwrap();
+            store
+                .storage_account_upsert(&StorageAccount {
+                    name: name.into(),
+                    subscription_id: Some("sub-dev".into()),
+                    kind: "StorageV2 (ADLS Gen2)".into(),
+                    region: "West Europe".into(),
+                    replication: "LRS".into(),
+                    tier: "Premium".into(),
+                    hns: name.ends_with("proddlp"),
+                    endpoint: format!("https://{name}.blob.core.windows.net"),
+                    attached_directly: false,
+                })
+                .unwrap();
         }
 
         // 4. User attaches a read-only SAS container outside the sign-in
-        store.attached_resource_insert(&AttachedResource {
-            id: "att-1".into(),
-            display_name: "dev-analytics-ro".into(),
-            resource_kind: ResourceKind::BlobContainer,
-            endpoint: "https://acme.blob.core.windows.net/readonly".into(),
-            auth_kind: AuthKind::SasToken,
-            keychain_ref: "arkived:connection:att-1".into(),
-        }).unwrap();
+        store
+            .attached_resource_insert(&AttachedResource {
+                id: "att-1".into(),
+                display_name: "dev-analytics-ro".into(),
+                resource_kind: ResourceKind::BlobContainer,
+                endpoint: "https://acme.blob.core.windows.net/readonly".into(),
+                auth_kind: AuthKind::SasToken,
+                keychain_ref: "arkived:connection:att-1".into(),
+            })
+            .unwrap();
 
         // 5. User picks a context: (si-hamza, sub-dev, stdlnphoenixproddlp)
         store.context_set_sign_in(Some("si-hamza")).unwrap();
         store.context_set_subscription(Some("sub-dev")).unwrap();
-        store.context_set_account(Some("stdlnphoenixproddlp")).unwrap();
+        store
+            .context_set_account(Some("stdlnphoenixproddlp"))
+            .unwrap();
 
         // 6. A destructive op runs; user picks "Allow always for this kind, any target"
         store.policy_memory_allow("set_tier", None).unwrap();
 
         // 7. Sanity: everything is readable
         assert_eq!(store.sign_in_list().unwrap().len(), 1);
-        assert_eq!(store.subscription_list_for_sign_in("si-hamza").unwrap().len(), 2);
-        assert_eq!(store.storage_account_list_for_subscription("sub-dev").unwrap().len(), 2);
+        assert_eq!(
+            store
+                .subscription_list_for_sign_in("si-hamza")
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            store
+                .storage_account_list_for_subscription("sub-dev")
+                .unwrap()
+                .len(),
+            2
+        );
         assert_eq!(store.attached_resource_list().unwrap().len(), 1);
         assert_eq!(
             store.context_get().unwrap(),
@@ -83,7 +110,9 @@ fn full_flow_add_signin_discover_pick_context_policy_memory() {
                 account_name: Some("stdlnphoenixproddlp".into()),
             }
         );
-        assert!(store.policy_memory_is_allowed("set_tier", Some("anywhere")).unwrap());
+        assert!(store
+            .policy_memory_is_allowed("set_tier", Some("anywhere"))
+            .unwrap());
     }
 
     // -- second process: reopen, verify persistence + policy_memory clear
@@ -92,8 +121,20 @@ fn full_flow_add_signin_discover_pick_context_policy_memory() {
 
         // persistent data survives
         assert_eq!(store.sign_in_list().unwrap().len(), 1);
-        assert_eq!(store.subscription_list_for_sign_in("si-hamza").unwrap().len(), 2);
-        assert_eq!(store.storage_account_list_for_subscription("sub-dev").unwrap().len(), 2);
+        assert_eq!(
+            store
+                .subscription_list_for_sign_in("si-hamza")
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            store
+                .storage_account_list_for_subscription("sub-dev")
+                .unwrap()
+                .len(),
+            2
+        );
         assert_eq!(store.attached_resource_list().unwrap().len(), 1);
         assert_eq!(
             store.context_get().unwrap().account_name.as_deref(),
@@ -102,11 +143,20 @@ fn full_flow_add_signin_discover_pick_context_policy_memory() {
 
         // session-scope policy memory was truncated
         let entries: Vec<PolicyAllowEntry> = store.policy_memory_list().unwrap();
-        assert_eq!(entries.len(), 0, "policy_memory must not survive process restart");
-        assert!(!store.policy_memory_is_allowed("set_tier", Some("anywhere")).unwrap());
+        assert_eq!(
+            entries.len(),
+            0,
+            "policy_memory must not survive process restart"
+        );
+        assert!(!store
+            .policy_memory_is_allowed("set_tier", Some("anywhere"))
+            .unwrap());
 
         // Cascade: deleting the sign-in nukes subscriptions (and via FK, any direct refs)
         store.sign_in_delete("si-hamza").unwrap();
-        assert!(store.subscription_list_for_sign_in("si-hamza").unwrap().is_empty());
+        assert!(store
+            .subscription_list_for_sign_in("si-hamza")
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/arkived-core/tests/foundation_integration.rs
+++ b/crates/arkived-core/tests/foundation_integration.rs
@@ -1,0 +1,112 @@
+//! End-to-end integration test for the foundation layer: Store + types + context.
+//!
+//! This test exercises the realistic flow a CLI `login` + `context use` would trigger.
+
+use arkived_core::store::{Store, SignIn, Subscription, StorageAccount, AttachedResource, CurrentContext, PolicyAllowEntry};
+use arkived_core::types::{AuthKind, ResourceKind};
+use chrono::Utc;
+use tempfile::tempdir;
+
+#[test]
+fn full_flow_add_signin_discover_pick_context_policy_memory() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join("state.db");
+
+    // -- first process: user signs in, discovery populates subs + accounts
+    {
+        let store = Store::open(&db).unwrap();
+
+        // 1. User signs in
+        store.sign_in_insert(&SignIn {
+            id: "si-hamza".into(),
+            display_name: "Hamza Abdagić".into(),
+            tenant_id: "tenant-abc".into(),
+            environment: "azure".into(),
+            user_principal: "hamza@horizon-tech.io".into(),
+            added_at: Utc::now(),
+        }).unwrap();
+
+        // 2. Discovery finds two subscriptions
+        for (id, name) in [("sub-dev", "din — development"), ("sub-prod", "Horizon Tech — Prod")] {
+            store.subscription_upsert(&Subscription {
+                id: id.into(),
+                sign_in_id: "si-hamza".into(),
+                name: name.into(),
+                tenant_id: "tenant-abc".into(),
+                discovered_at: Utc::now(),
+            }).unwrap();
+        }
+
+        // 3. Discovery finds storage accounts under `sub-dev`
+        for name in ["stdlnphoenixproddlp", "stdlnphoenixdevfunc"] {
+            store.storage_account_upsert(&StorageAccount {
+                name: name.into(),
+                subscription_id: Some("sub-dev".into()),
+                kind: "StorageV2 (ADLS Gen2)".into(),
+                region: "West Europe".into(),
+                replication: "LRS".into(),
+                tier: "Premium".into(),
+                hns: name.ends_with("proddlp"),
+                endpoint: format!("https://{name}.blob.core.windows.net"),
+                attached_directly: false,
+            }).unwrap();
+        }
+
+        // 4. User attaches a read-only SAS container outside the sign-in
+        store.attached_resource_insert(&AttachedResource {
+            id: "att-1".into(),
+            display_name: "dev-analytics-ro".into(),
+            resource_kind: ResourceKind::BlobContainer,
+            endpoint: "https://acme.blob.core.windows.net/readonly".into(),
+            auth_kind: AuthKind::SasToken,
+            keychain_ref: "arkived:connection:att-1".into(),
+        }).unwrap();
+
+        // 5. User picks a context: (si-hamza, sub-dev, stdlnphoenixproddlp)
+        store.context_set_sign_in(Some("si-hamza")).unwrap();
+        store.context_set_subscription(Some("sub-dev")).unwrap();
+        store.context_set_account(Some("stdlnphoenixproddlp")).unwrap();
+
+        // 6. A destructive op runs; user picks "Allow always for this kind, any target"
+        store.policy_memory_allow("set_tier", None).unwrap();
+
+        // 7. Sanity: everything is readable
+        assert_eq!(store.sign_in_list().unwrap().len(), 1);
+        assert_eq!(store.subscription_list_for_sign_in("si-hamza").unwrap().len(), 2);
+        assert_eq!(store.storage_account_list_for_subscription("sub-dev").unwrap().len(), 2);
+        assert_eq!(store.attached_resource_list().unwrap().len(), 1);
+        assert_eq!(
+            store.context_get().unwrap(),
+            CurrentContext {
+                sign_in_id: Some("si-hamza".into()),
+                subscription_id: Some("sub-dev".into()),
+                account_name: Some("stdlnphoenixproddlp".into()),
+            }
+        );
+        assert!(store.policy_memory_is_allowed("set_tier", Some("anywhere")).unwrap());
+    }
+
+    // -- second process: reopen, verify persistence + policy_memory clear
+    {
+        let store = Store::open(&db).unwrap();
+
+        // persistent data survives
+        assert_eq!(store.sign_in_list().unwrap().len(), 1);
+        assert_eq!(store.subscription_list_for_sign_in("si-hamza").unwrap().len(), 2);
+        assert_eq!(store.storage_account_list_for_subscription("sub-dev").unwrap().len(), 2);
+        assert_eq!(store.attached_resource_list().unwrap().len(), 1);
+        assert_eq!(
+            store.context_get().unwrap().account_name.as_deref(),
+            Some("stdlnphoenixproddlp"),
+        );
+
+        // session-scope policy memory was truncated
+        let entries: Vec<PolicyAllowEntry> = store.policy_memory_list().unwrap();
+        assert_eq!(entries.len(), 0, "policy_memory must not survive process restart");
+        assert!(!store.policy_memory_is_allowed("set_tier", Some("anywhere")).unwrap());
+
+        // Cascade: deleting the sign-in nukes subscriptions (and via FK, any direct refs)
+        store.sign_in_delete("si-hamza").unwrap();
+        assert!(store.subscription_list_for_sign_in("si-hamza").unwrap().is_empty());
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75"
+channel = "1.85"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Builds the foundation layer of `arkived-core` per the v0.1.0 design spec. Everything above this layer (concrete `AuthProvider` impls, `StorageBackend` + `AzureBlobBackend`, CLI verbs, Tauri IPC replacing stubs) builds on these pieces.

- Extended `Error` enum (NotFound / Conflict / Throttled / NetworkTransient / AuthExpired / AuthFailed)
- `ArkivedConfig` — preferences-only TOML (zero credentials, zero connection metadata) with discovery chain
- `ProgressEvent` + `ProgressSink` trait (+ `NoopSink`, `MemorySink`)
- Shared types: `ResourceKind`, `AuthKind`, `AzureEnvironment`
- `AuthProvider` + `Credential` trait skeletons
- `CredentialStore` trait + `OsKeyring` impl (via `keyring` crate)
- `Ctx` struct bundling auth/policy/progress/cancel/request_id
- SQLite `Store` with 6 tables: sign_in, subscription, storage_account, attached_resource, context, policy_memory
- Session-scope clear of `policy_memory` on `Store::open`
- Foreign-key pragma enabled on every connection
- End-to-end integration test exercising the realistic flow across a simulated process restart

## Architecture notes

- Connections, sign-ins, subscriptions, storage accounts all live in SQLite (no config files hold connection metadata — matches ASE's model).
- Secrets never leave the OS keychain; the DB only holds references (`keychain_ref`).
- `StorageBackend` remains `pub(crate)`; public API stays Azure-native.
- Destructive operations will route through `Policy::confirm` via `Ctx`; the foundation threads it end-to-end so the Backend plan can enforce the invariant without rework.

## MSRV change

Workspace MSRV bumped from **1.75 → 1.85**. The modern foundation dep chain (`uuid`, `keyring`, transitive `getrandom 0.4.x`) requires `edition2024`, stabilized in Rust 1.85. This was flagged as likely in the design spec's risk section. Updated: `rust-toolchain.toml`, workspace `rust-version`, CI matrix, CHANGELOG, CONTRIBUTING, ROADMAP, and app/README.

## Deferred (by design)

- **Full DB encryption at rest** — spec §Store calls for it; implementation review showed metadata is non-sensitive (secrets live in keychain, DB only has references). Deferred to a dedicated hardening plan rather than blocking foundation delivery. Captured in the design spec's deferred-decisions list and noted in `store/mod.rs` docs.
- Concrete `AuthProvider` impls — the Auth plan.
- `StorageBackend` trait flesh-out + `AzureBlobBackend` — the Backend plan.
- Concrete `Policy` impls (`StdinPolicy`, `TauriModalPolicy`, `NonInteractivePolicy`) — the Policy plan.

## Verification

- `cargo test -p arkived-core` — 41 unit + 1 integration test pass, 1 ignored (OS keychain live test)
- `cargo clippy -p arkived-core --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo build --workspace` — clean

## Process

Built via the superpowers:subagent-driven-development workflow: 20 TDD tasks (test → fail → impl → pass → commit) from `docs/superpowers/plans/2026-04-20-v0.1.0-foundation.md`. Implementers used Haiku; final holistic review used Opus and approved with minor cleanups that are now applied.

## Test plan

- [ ] CI MSRV job passes on Rust 1.85
- [ ] CI test matrix (Linux/macOS/Windows) passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] Tauri app in `app/src-tauri` still builds unchanged (workspace excludes it but uses separate deps)
- [ ] Squash vs. merge decision made before merging