### PR TITLE
feat(core): v0.1.0 backend — hand-rolled Blob REST client with 5 CRUD operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "httpdate",
  "keyring",
  "mockito",
+ "quick-xml 0.36.2",
  "reqwest 0.12.28",
  "rusqlite",
  "secrecy",
@@ -147,6 +148,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
 ]
 
@@ -2058,6 +2060,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
@@ -2265,6 +2277,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2284,12 +2297,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -2326,7 +2341,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3121,7 +3136,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures",
- "quick-xml",
+ "quick-xml 0.39.2",
  "serde",
  "serde_json",
  "url",
@@ -3204,6 +3219,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3361,6 +3382,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+quick-xml = { version = "0.36", features = ["serialize"] }
 
 # CLI
 clap = { version = "~4.4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ azure_storage_blob = "0.11"
 hmac = "0.12"
 sha2 = "0.10"
 base64 = "0.22"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 url = "2"
 urlencoding = "2"
 mockito = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sha2 = "0.10"
 base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 url = "2"
+urlencoding = "2"
 mockito = "1"
 httpdate = "1"
 

--- a/crates/arkived-core/Cargo.toml
+++ b/crates/arkived-core/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = { workspace = true }
 url = { workspace = true }
 time = { workspace = true }
 quick-xml = { workspace = true }
+httpdate = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/arkived-core/Cargo.toml
+++ b/crates/arkived-core/Cargo.toml
@@ -37,6 +37,7 @@ base64 = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
 time = { workspace = true }
+quick-xml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/arkived-core/Cargo.toml
+++ b/crates/arkived-core/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
+urlencoding = { workspace = true }
 time = { workspace = true }
 quick-xml = { workspace = true }
 httpdate = { workspace = true }

--- a/crates/arkived-core/src/backend/azure/auth_bridge.rs
+++ b/crates/arkived-core/src/backend/azure/auth_bridge.rs
@@ -1,1 +1,198 @@
-//! Apply a `ResolvedCredential` to outgoing requests. Filled in Task 5.
+//! Apply a [`ResolvedCredential`] to an outgoing `reqwest::Request`.
+//!
+//! - **Entra**: add `Authorization: Bearer <token>`. Token acquired via
+//!   the `TokenCredential` with scope `https://storage.azure.com/.default`.
+//! - **SharedKey**: sign with HMAC-SHA256 via [`crate::auth::shared_key::sign`]
+//!   and set `Authorization: SharedKey <account>:<sig>`. This needs to happen
+//!   *after* headers are finalized, so this module exposes a post-build hook.
+//! - **SAS**: merge the SAS query string into the URL. If both have a `sig=`
+//!   the SAS wins.
+//! - **Anonymous**: no-op.
+
+use crate::auth::shared_key::{sign, SignRequest};
+use crate::auth::ResolvedCredential;
+use crate::Error;
+use azure_core::credentials::TokenCredential;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
+use reqwest::{Request, Url};
+use std::sync::Arc;
+
+/// `x-ms-version` header value — pinned to a stable REST API version.
+pub(crate) const MS_VERSION: &str = "2022-11-02";
+
+/// Decorate the URL for SAS credentials (append the SAS query). Called
+/// *before* the request is built so subsequent signing sees the final URL.
+pub(crate) fn decorate_url(cred: &ResolvedCredential, url: &mut Url) {
+    if let ResolvedCredential::Sas(sas) = cred {
+        use secrecy::ExposeSecret;
+        let sas_str = sas.expose_secret();
+        // Merge SAS query params into the URL, preserving any that already exist.
+        let existing = url.query().map(String::from);
+        let merged = match existing {
+            Some(q) if !q.is_empty() => format!("{q}&{sas_str}"),
+            _ => sas_str.to_string(),
+        };
+        url.set_query(Some(&merged));
+    }
+}
+
+/// Apply auth to a built request. This is the single choke point.
+///
+/// Sets `x-ms-date` and `x-ms-version` for all methods. For SharedKey,
+/// signs after all headers are set. For Entra, acquires a token and
+/// sets the Bearer header.
+pub(crate) async fn apply_auth(
+    cred: &ResolvedCredential,
+    request: &mut Request,
+) -> crate::Result<()> {
+    // Always set the date + API version headers.
+    let date = httpdate::fmt_http_date(std::time::SystemTime::now());
+    request.headers_mut().insert(
+        HeaderName::from_static("x-ms-date"),
+        HeaderValue::from_str(&date).map_err(|e| Error::Backend(format!("x-ms-date: {e}")))?,
+    );
+    request.headers_mut().insert(
+        HeaderName::from_static("x-ms-version"),
+        HeaderValue::from_static(MS_VERSION),
+    );
+
+    match cred {
+        ResolvedCredential::Anonymous | ResolvedCredential::Sas(_) => Ok(()),
+        ResolvedCredential::Entra(tc) => apply_entra(tc.clone(), request).await,
+        ResolvedCredential::SharedKey { account_name, key } => {
+            apply_shared_key(account_name, key, request)
+        }
+    }
+}
+
+async fn apply_entra(
+    tc: Arc<dyn TokenCredential>,
+    request: &mut Request,
+) -> crate::Result<()> {
+    let token = tc
+        .get_token(&["https://storage.azure.com/.default"], None)
+        .await
+        .map_err(|e| Error::AuthFailed(format!("get_token: {e}")))?;
+    let header = format!("Bearer {}", token.token.secret());
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&header).map_err(|e| Error::AuthFailed(format!("bearer header: {e}")))?,
+    );
+    Ok(())
+}
+
+fn apply_shared_key(
+    account_name: &str,
+    key: &secrecy::SecretString,
+    request: &mut Request,
+) -> crate::Result<()> {
+    let method = request.method().as_str().to_string();
+    let url = request.url().clone();
+
+    let header_pairs: Vec<(String, String)> = request
+        .headers()
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_str().to_string(),
+                v.to_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+
+    let signed = sign(
+        account_name,
+        key,
+        &SignRequest {
+            method: &method,
+            url: &url,
+            headers: &header_pairs,
+        },
+    )
+    .map_err(|e| Error::AuthFailed(format!("SharedKey sign: {e:?}")))?;
+
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&signed).map_err(|e| Error::AuthFailed(format!("auth header: {e}")))?,
+    );
+    Ok(())
+}
+
+/// Copy a reqwest `HeaderMap` into the `Vec<(String, String)>` shape the
+/// signer consumes. Exposed for testing.
+#[cfg(test)]
+pub(crate) fn headers_as_pairs(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn build_get(url: &str) -> Request {
+        reqwest::Client::new().get(url).build().unwrap()
+    }
+
+    #[tokio::test]
+    async fn anonymous_sets_date_and_version_only() {
+        let mut req = build_get("https://example.com/container");
+        apply_auth(&ResolvedCredential::Anonymous, &mut req).await.unwrap();
+        assert!(req.headers().contains_key("x-ms-date"));
+        assert_eq!(
+            req.headers().get("x-ms-version").unwrap(),
+            MS_VERSION
+        );
+        assert!(!req.headers().contains_key(AUTHORIZATION));
+    }
+
+    #[tokio::test]
+    async fn shared_key_sets_signed_authorization() {
+        let mut req = build_get("https://acme.blob.core.windows.net/?comp=list");
+        apply_auth(
+            &ResolvedCredential::SharedKey {
+                account_name: "acme".into(),
+                key: SecretString::new(
+                    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==".into(),
+                ),
+            },
+            &mut req,
+        )
+        .await
+        .unwrap();
+        let auth = req.headers().get(AUTHORIZATION).unwrap().to_str().unwrap();
+        assert!(auth.starts_with("SharedKey acme:"));
+    }
+
+    #[test]
+    fn sas_is_merged_into_url_query() {
+        let mut url = Url::parse("https://acme.blob.core.windows.net/c/b").unwrap();
+        let cred = ResolvedCredential::Sas(SecretString::new("sv=2022&sig=XYZ".into()));
+        decorate_url(&cred, &mut url);
+        assert_eq!(url.query(), Some("sv=2022&sig=XYZ"));
+
+        let mut url2 = Url::parse("https://acme.blob.core.windows.net/c?existing=1").unwrap();
+        decorate_url(&cred, &mut url2);
+        assert_eq!(url2.query(), Some("existing=1&sv=2022&sig=XYZ"));
+    }
+
+    #[test]
+    fn sas_decoration_is_noop_for_non_sas() {
+        let mut url = Url::parse("https://acme.blob.core.windows.net/c/b").unwrap();
+        decorate_url(&ResolvedCredential::Anonymous, &mut url);
+        assert_eq!(url.query(), None);
+    }
+
+    #[test]
+    fn headers_as_pairs_roundtrips() {
+        let mut h = HeaderMap::new();
+        h.insert("x-ms-date", "Mon".parse().unwrap());
+        h.insert("x-ms-version", "2022-11-02".parse().unwrap());
+        let pairs = headers_as_pairs(&h);
+        assert_eq!(pairs.len(), 2);
+        assert!(pairs.iter().any(|(k, v)| k == "x-ms-date" && v == "Mon"));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/auth_bridge.rs
+++ b/crates/arkived-core/src/backend/azure/auth_bridge.rs
@@ -13,7 +13,9 @@ use crate::auth::shared_key::{sign, SignRequest};
 use crate::auth::ResolvedCredential;
 use crate::Error;
 use azure_core::credentials::TokenCredential;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
+#[cfg(test)]
+use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION};
 use reqwest::{Request, Url};
 use std::sync::Arc;
 
@@ -65,10 +67,7 @@ pub(crate) async fn apply_auth(
     }
 }
 
-async fn apply_entra(
-    tc: Arc<dyn TokenCredential>,
-    request: &mut Request,
-) -> crate::Result<()> {
+async fn apply_entra(tc: Arc<dyn TokenCredential>, request: &mut Request) -> crate::Result<()> {
     let token = tc
         .get_token(&["https://storage.azure.com/.default"], None)
         .await
@@ -76,7 +75,8 @@ async fn apply_entra(
     let header = format!("Bearer {}", token.token.secret());
     request.headers_mut().insert(
         AUTHORIZATION,
-        HeaderValue::from_str(&header).map_err(|e| Error::AuthFailed(format!("bearer header: {e}")))?,
+        HeaderValue::from_str(&header)
+            .map_err(|e| Error::AuthFailed(format!("bearer header: {e}")))?,
     );
     Ok(())
 }
@@ -92,12 +92,7 @@ fn apply_shared_key(
     let header_pairs: Vec<(String, String)> = request
         .headers()
         .iter()
-        .map(|(k, v)| {
-            (
-                k.as_str().to_string(),
-                v.to_str().unwrap_or("").to_string(),
-            )
-        })
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
         .collect();
 
     let signed = sign(
@@ -113,7 +108,8 @@ fn apply_shared_key(
 
     request.headers_mut().insert(
         AUTHORIZATION,
-        HeaderValue::from_str(&signed).map_err(|e| Error::AuthFailed(format!("auth header: {e}")))?,
+        HeaderValue::from_str(&signed)
+            .map_err(|e| Error::AuthFailed(format!("auth header: {e}")))?,
     );
     Ok(())
 }
@@ -140,12 +136,11 @@ mod tests {
     #[tokio::test]
     async fn anonymous_sets_date_and_version_only() {
         let mut req = build_get("https://example.com/container");
-        apply_auth(&ResolvedCredential::Anonymous, &mut req).await.unwrap();
+        apply_auth(&ResolvedCredential::Anonymous, &mut req)
+            .await
+            .unwrap();
         assert!(req.headers().contains_key("x-ms-date"));
-        assert_eq!(
-            req.headers().get("x-ms-version").unwrap(),
-            MS_VERSION
-        );
+        assert_eq!(req.headers().get("x-ms-version").unwrap(), MS_VERSION);
         assert!(!req.headers().contains_key(AUTHORIZATION));
     }
 

--- a/crates/arkived-core/src/backend/azure/auth_bridge.rs
+++ b/crates/arkived-core/src/backend/azure/auth_bridge.rs
@@ -1,0 +1,1 @@
+//! Apply a `ResolvedCredential` to outgoing requests. Filled in Task 5.

--- a/crates/arkived-core/src/backend/azure/error.rs
+++ b/crates/arkived-core/src/backend/azure/error.rs
@@ -30,11 +30,11 @@ pub(crate) fn map_rest_error(
 ) -> Error {
     // Parse body as Azure error; if that fails, fall through to Backend with the raw text.
     let parsed: Option<AzureError> = from_str(body).ok();
-    let code = parsed.as_ref().map(|e| e.code.as_str()).unwrap_or("Unknown");
-    let message = parsed
+    let code = parsed
         .as_ref()
-        .map(|e| e.message.as_str())
-        .unwrap_or(body);
+        .map(|e| e.code.as_str())
+        .unwrap_or("Unknown");
+    let message = parsed.as_ref().map(|e| e.message.as_str()).unwrap_or(body);
 
     match (status.as_u16(), code) {
         (404, _) => Error::NotFound {

--- a/crates/arkived-core/src/backend/azure/error.rs
+++ b/crates/arkived-core/src/backend/azure/error.rs
@@ -1,1 +1,135 @@
-//! Azure REST error → `crate::Error` mapping. Filled in Task 4.
+//! Azure REST error → `crate::Error` mapping.
+//!
+//! Azure returns errors as an XML body `<Error><Code>...</Code><Message>...</Message></Error>`
+//! with a status code. We map well-known codes (`BlobNotFound`,
+//! `ContainerNotFound`, `ConditionNotMet`, `ServerBusy`, …) to specific
+//! `crate::Error` variants; everything else becomes `Error::Backend(msg)`.
+
+use crate::Error;
+use quick_xml::de::from_str;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Parsed Azure error body.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AzureError {
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "Message")]
+    pub message: String,
+}
+
+/// Map a non-success HTTP response to a `crate::Error`.
+///
+/// Takes the response status and body text and dispatches to the right
+/// variant. Also reads the `x-ms-retry-after` header for `Throttled`.
+pub(crate) fn map_rest_error(
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+    body: &str,
+) -> Error {
+    // Parse body as Azure error; if that fails, fall through to Backend with the raw text.
+    let parsed: Option<AzureError> = from_str(body).ok();
+    let code = parsed.as_ref().map(|e| e.code.as_str()).unwrap_or("Unknown");
+    let message = parsed
+        .as_ref()
+        .map(|e| e.message.as_str())
+        .unwrap_or(body);
+
+    match (status.as_u16(), code) {
+        (404, _) => Error::NotFound {
+            resource: format!("{code}: {message}"),
+        },
+        (403, _) => Error::AuthFailed(format!("{code}: {message}")),
+        (401, _) => Error::AuthExpired,
+        (409, "BlobAlreadyExists") | (412, _) => Error::Conflict {
+            detail: format!("{code}: {message}"),
+            etag: headers
+                .get("etag")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string()),
+        },
+        (503 | 429, _) => {
+            let retry_after = headers
+                .get("x-ms-retry-after")
+                .or_else(|| headers.get("retry-after"))
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or(Duration::from_secs(3));
+            Error::Throttled { retry_after }
+        }
+        (500..=599, _) => Error::Backend(format!("server error {status}: {code}: {message}")),
+        _ => Error::Backend(format!("HTTP {status}: {code}: {message}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::{header::HeaderMap, StatusCode};
+
+    fn hdr(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    const BLOB_NOT_FOUND: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<Error><Code>BlobNotFound</Code><Message>The specified blob does not exist.</Message></Error>"#;
+
+    #[test]
+    fn map_404_to_not_found() {
+        let err = map_rest_error(StatusCode::NOT_FOUND, &hdr(&[]), BLOB_NOT_FOUND);
+        assert!(matches!(err, Error::NotFound { .. }));
+    }
+
+    #[test]
+    fn map_401_to_auth_expired() {
+        let err = map_rest_error(StatusCode::UNAUTHORIZED, &hdr(&[]), "");
+        assert!(matches!(err, Error::AuthExpired));
+    }
+
+    #[test]
+    fn map_403_to_auth_failed() {
+        let err = map_rest_error(StatusCode::FORBIDDEN, &hdr(&[]), BLOB_NOT_FOUND);
+        assert!(matches!(err, Error::AuthFailed(_)));
+    }
+
+    #[test]
+    fn map_503_to_throttled_with_retry_after() {
+        let err = map_rest_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &hdr(&[("x-ms-retry-after", "7")]),
+            "",
+        );
+        match err {
+            Error::Throttled { retry_after } => assert_eq!(retry_after, Duration::from_secs(7)),
+            other => panic!("expected Throttled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_412_to_conflict_with_etag() {
+        let err = map_rest_error(
+            StatusCode::PRECONDITION_FAILED,
+            &hdr(&[("etag", "0x8DCABCDEF")]),
+            r#"<Error><Code>ConditionNotMet</Code><Message>.</Message></Error>"#,
+        );
+        match err {
+            Error::Conflict { etag, .. } => assert_eq!(etag.as_deref(), Some("0x8DCABCDEF")),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_body_becomes_backend_error() {
+        let err = map_rest_error(StatusCode::IM_A_TEAPOT, &hdr(&[]), "not xml!");
+        assert!(matches!(err, Error::Backend(_)));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/error.rs
+++ b/crates/arkived-core/src/backend/azure/error.rs
@@ -1,0 +1,1 @@
+//! Azure REST error → `crate::Error` mapping. Filled in Task 4.

--- a/crates/arkived-core/src/backend/azure/http.rs
+++ b/crates/arkived-core/src/backend/azure/http.rs
@@ -46,7 +46,35 @@ pub(crate) struct HttpPipeline<'a> {
 impl<'a> HttpPipeline<'a> {
     /// Send a request with auth + retry, returning the raw response on 2xx.
     pub async fn send(&self, tmpl: RequestTemplate) -> crate::Result<Response> {
-        with_retries(|| async { self.send_once(tmpl.clone()).await }).await
+        let request_id = uuid::Uuid::new_v4();
+        let span = tracing::info_span!(
+            "azure_request",
+            request_id = %request_id,
+            method = %tmpl.method,
+            host = %tmpl.url.host_str().unwrap_or("?"),
+            path = %tmpl.url.path(),
+            auth = ?self.credential.kind(),
+        );
+        let _enter = span.enter();
+        let started = std::time::Instant::now();
+        let result = with_retries(|| async { self.send_once(tmpl.clone()).await }).await;
+        match &result {
+            Ok(resp) => {
+                tracing::info!(
+                    status = %resp.status(),
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "azure_request ok"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    error = %e,
+                    "azure_request failed"
+                );
+            }
+        }
+        result
     }
 
     async fn send_once(&self, mut tmpl: RequestTemplate) -> crate::Result<Response> {

--- a/crates/arkived-core/src/backend/azure/http.rs
+++ b/crates/arkived-core/src/backend/azure/http.rs
@@ -1,0 +1,1 @@
+//! reqwest-backed request pipeline. Filled in Task 6.

--- a/crates/arkived-core/src/backend/azure/http.rs
+++ b/crates/arkived-core/src/backend/azure/http.rs
@@ -80,9 +80,7 @@ impl<'a> HttpPipeline<'a> {
     async fn send_once(&self, mut tmpl: RequestTemplate) -> crate::Result<Response> {
         decorate_url(self.credential, &mut tmpl.url);
 
-        let mut builder = self
-            .http
-            .request(tmpl.method.clone(), tmpl.url.clone());
+        let mut builder = self.http.request(tmpl.method.clone(), tmpl.url.clone());
         for (k, v) in &tmpl.headers {
             builder = builder.header(k, v);
         }
@@ -132,7 +130,10 @@ mod tests {
 
         let http = reqwest::Client::new();
         let cred = ResolvedCredential::Anonymous;
-        let pipeline = HttpPipeline { http: &http, credential: &cred };
+        let pipeline = HttpPipeline {
+            http: &http,
+            credential: &cred,
+        };
 
         let url = url::Url::parse(&format!("{}/hello", server.url())).unwrap();
         let resp = pipeline
@@ -162,7 +163,10 @@ mod tests {
 
         let http = reqwest::Client::new();
         let cred = ResolvedCredential::Anonymous;
-        let pipeline = HttpPipeline { http: &http, credential: &cred };
+        let pipeline = HttpPipeline {
+            http: &http,
+            credential: &cred,
+        };
         let url = url::Url::parse(&format!("{}/missing", server.url())).unwrap();
         let err = pipeline
             .send(RequestTemplate {

--- a/crates/arkived-core/src/backend/azure/http.rs
+++ b/crates/arkived-core/src/backend/azure/http.rs
@@ -1,1 +1,150 @@
-//! reqwest-backed request pipeline. Filled in Task 6.
+//! The reqwest-backed request pipeline.
+//!
+//! Every request to Azure flows through [`HttpPipeline::send`]:
+//! 1. Clone the URL and apply SAS decoration.
+//! 2. Build the request with caller-supplied method/headers/body.
+//! 3. Apply auth (sets `x-ms-date`, `x-ms-version`, `Authorization`).
+//! 4. Send; on success, hand back the response.
+//! 5. On transient error (throttle / 5xx / network), retry with backoff
+//!    via [`super::retry::with_retries`].
+//! 6. On terminal error, convert to `crate::Error` via [`super::error::map_rest_error`].
+
+use crate::auth::ResolvedCredential;
+use crate::backend::azure::auth_bridge::{apply_auth, decorate_url};
+use crate::backend::azure::error::map_rest_error;
+use crate::backend::azure::retry::with_retries;
+use crate::Error;
+use bytes::Bytes;
+use reqwest::{Method, Response};
+
+/// Per-request body: unit for no-body, Bytes for inline, stream handled by caller.
+#[derive(Debug, Clone)]
+pub(crate) enum Body {
+    /// No request body.
+    Empty,
+    /// Inline bytes body (content-length is set automatically).
+    #[allow(dead_code)]
+    Bytes(Bytes),
+}
+
+/// A single request template. Cloned across retries.
+#[derive(Debug, Clone)]
+pub(crate) struct RequestTemplate {
+    pub method: Method,
+    pub url: url::Url,
+    /// Name-value header pairs to set on the request (in addition to auth).
+    pub headers: Vec<(String, String)>,
+    pub body: Body,
+}
+
+/// Outbound pipeline.
+pub(crate) struct HttpPipeline<'a> {
+    pub http: &'a reqwest::Client,
+    pub credential: &'a ResolvedCredential,
+}
+
+impl<'a> HttpPipeline<'a> {
+    /// Send a request with auth + retry, returning the raw response on 2xx.
+    pub async fn send(&self, tmpl: RequestTemplate) -> crate::Result<Response> {
+        with_retries(|| async { self.send_once(tmpl.clone()).await }).await
+    }
+
+    async fn send_once(&self, mut tmpl: RequestTemplate) -> crate::Result<Response> {
+        decorate_url(self.credential, &mut tmpl.url);
+
+        let mut builder = self
+            .http
+            .request(tmpl.method.clone(), tmpl.url.clone());
+        for (k, v) in &tmpl.headers {
+            builder = builder.header(k, v);
+        }
+        builder = match tmpl.body {
+            Body::Empty => builder.header("content-length", "0"),
+            Body::Bytes(b) => builder.body(b),
+        };
+
+        let mut request = builder
+            .build()
+            .map_err(|e| Error::Backend(format!("build request: {e}")))?;
+
+        apply_auth(self.credential, &mut request).await?;
+
+        let resp = self
+            .http
+            .execute(request)
+            .await
+            .map_err(|e| Error::NetworkTransient(format!("execute: {e}")))?;
+
+        if resp.status().is_success() {
+            return Ok(resp);
+        }
+
+        // Pull headers + body for error mapping.
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = resp.text().await.unwrap_or_default();
+        Err(map_rest_error(status, &headers, &body))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ResolvedCredential;
+
+    #[tokio::test]
+    async fn sends_anonymous_get_returns_response_on_2xx() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/hello")
+            .with_status(200)
+            .with_body("ok")
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let cred = ResolvedCredential::Anonymous;
+        let pipeline = HttpPipeline { http: &http, credential: &cred };
+
+        let url = url::Url::parse(&format!("{}/hello", server.url())).unwrap();
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn maps_404_to_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/missing")
+            .with_status(404)
+            .with_body(
+                r#"<?xml version="1.0"?><Error><Code>BlobNotFound</Code><Message>gone</Message></Error>"#,
+            )
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let cred = ResolvedCredential::Anonymous;
+        let pipeline = HttpPipeline { http: &http, credential: &cred };
+        let url = url::Url::parse(&format!("{}/missing", server.url())).unwrap();
+        let err = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound { .. }));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/mod.rs
+++ b/crates/arkived-core/src/backend/azure/mod.rs
@@ -16,6 +16,12 @@ pub(crate) mod retry;
 pub(crate) mod xml;
 
 use crate::auth::ResolvedCredential;
+use crate::backend::types::{
+    BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range, WriteOpts, WriteResult,
+};
+use crate::backend::StorageBackend;
+use crate::Ctx;
+use async_trait::async_trait;
 use std::sync::Arc;
 
 /// Azure Blob / ADLS Gen2 backend.
@@ -24,7 +30,6 @@ use std::sync::Arc;
 /// verbs (`list_containers`, `list_blobs`, `read_blob`, `write_blob`,
 /// `delete_blob`).
 #[derive(Clone)]
-#[allow(dead_code)] // Fields used by ops impls in Tasks 9–13.
 pub struct AzureBlobBackend {
     /// Account blob endpoint URL (no trailing slash), e.g.
     /// `https://acme.blob.core.windows.net`.
@@ -77,10 +82,58 @@ impl AzureBlobBackend {
     }
 }
 
+#[async_trait]
+impl StorageBackend for AzureBlobBackend {
+    fn name(&self) -> &'static str {
+        "azure-blob"
+    }
+
+    async fn list_containers(
+        &self,
+        _ctx: &Ctx,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>> {
+        AzureBlobBackend::list_containers(self, continuation).await
+    }
+
+    async fn list_blobs(
+        &self,
+        _ctx: &Ctx,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>> {
+        AzureBlobBackend::list_blobs(self, container, prefix, delimiter, continuation).await
+    }
+
+    async fn read_blob(
+        &self,
+        _ctx: &Ctx,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream> {
+        AzureBlobBackend::read_blob(self, path, range).await
+    }
+
+    async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult> {
+        AzureBlobBackend::write_blob(self, ctx, path, body, opts).await
+    }
+
+    async fn delete_blob(&self, ctx: &Ctx, path: &BlobPath, opts: DeleteOpts) -> crate::Result<()> {
+        AzureBlobBackend::delete_blob(self, ctx, path, opts).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::ResolvedCredential;
 
     #[test]
     fn construction_succeeds() {
@@ -126,62 +179,5 @@ mod tests {
             b.endpoint().as_str(),
             "https://acmeprod.blob.core.chinacloudapi.cn/"
         );
-    }
-}
-
-use crate::backend::types::{BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range, WriteOpts, WriteResult};
-use crate::backend::StorageBackend;
-use crate::Ctx;
-use async_trait::async_trait;
-
-#[async_trait]
-impl StorageBackend for AzureBlobBackend {
-    fn name(&self) -> &'static str { "azure-blob" }
-
-    async fn list_containers(
-        &self,
-        _ctx: &Ctx,
-        continuation: Option<String>,
-    ) -> crate::Result<Page<Container>> {
-        AzureBlobBackend::list_containers(self, continuation).await
-    }
-
-    async fn list_blobs(
-        &self,
-        _ctx: &Ctx,
-        container: &str,
-        prefix: Option<&str>,
-        delimiter: Option<&str>,
-        continuation: Option<String>,
-    ) -> crate::Result<Page<BlobEntry>> {
-        AzureBlobBackend::list_blobs(self, container, prefix, delimiter, continuation).await
-    }
-
-    async fn read_blob(
-        &self,
-        _ctx: &Ctx,
-        path: &BlobPath,
-        range: Option<Range>,
-    ) -> crate::Result<ByteStream> {
-        AzureBlobBackend::read_blob(self, path, range).await
-    }
-
-    async fn write_blob(
-        &self,
-        ctx: &Ctx,
-        path: &BlobPath,
-        body: ByteStream,
-        opts: WriteOpts,
-    ) -> crate::Result<WriteResult> {
-        AzureBlobBackend::write_blob(self, ctx, path, body, opts).await
-    }
-
-    async fn delete_blob(
-        &self,
-        ctx: &Ctx,
-        path: &BlobPath,
-        opts: DeleteOpts,
-    ) -> crate::Result<()> {
-        AzureBlobBackend::delete_blob(self, ctx, path, opts).await
     }
 }

--- a/crates/arkived-core/src/backend/azure/mod.rs
+++ b/crates/arkived-core/src/backend/azure/mod.rs
@@ -58,6 +58,23 @@ impl AzureBlobBackend {
     pub fn endpoint(&self) -> &url::Url {
         &self.endpoint
     }
+
+    /// Construct from a storage account name + Azure environment.
+    ///
+    /// Builds the endpoint URL as `https://<account>.blob.<env_suffix>`.
+    pub fn for_account(
+        account_name: &str,
+        environment: &crate::types::AzureEnvironment,
+        credential: ResolvedCredential,
+    ) -> crate::Result<Self> {
+        let endpoint = url::Url::parse(&format!(
+            "https://{}.blob.{}",
+            account_name,
+            environment.storage_suffix()
+        ))
+        .map_err(|e| crate::Error::Backend(format!("build endpoint: {e}")))?;
+        Self::new(endpoint, credential)
+    }
 }
 
 #[cfg(test)]
@@ -79,6 +96,36 @@ mod tests {
         let dbg = format!("{b:?}");
         assert!(dbg.contains("AzureBlobBackend"));
         assert!(dbg.contains("acme.blob.core.windows.net"));
+    }
+
+    #[test]
+    fn for_account_builds_public_endpoint() {
+        use crate::types::AzureEnvironment;
+        let b = AzureBlobBackend::for_account(
+            "acmeprod",
+            &AzureEnvironment::Public,
+            ResolvedCredential::Anonymous,
+        )
+        .unwrap();
+        assert_eq!(
+            b.endpoint().as_str(),
+            "https://acmeprod.blob.core.windows.net/"
+        );
+    }
+
+    #[test]
+    fn for_account_builds_china_endpoint() {
+        use crate::types::AzureEnvironment;
+        let b = AzureBlobBackend::for_account(
+            "acmeprod",
+            &AzureEnvironment::China,
+            ResolvedCredential::Anonymous,
+        )
+        .unwrap();
+        assert_eq!(
+            b.endpoint().as_str(),
+            "https://acmeprod.blob.core.chinacloudapi.cn/"
+        );
     }
 }
 

--- a/crates/arkived-core/src/backend/azure/mod.rs
+++ b/crates/arkived-core/src/backend/azure/mod.rs
@@ -81,3 +81,60 @@ mod tests {
         assert!(dbg.contains("acme.blob.core.windows.net"));
     }
 }
+
+use crate::backend::types::{BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range, WriteOpts, WriteResult};
+use crate::backend::StorageBackend;
+use crate::Ctx;
+use async_trait::async_trait;
+
+#[async_trait]
+impl StorageBackend for AzureBlobBackend {
+    fn name(&self) -> &'static str { "azure-blob" }
+
+    async fn list_containers(
+        &self,
+        _ctx: &Ctx,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>> {
+        AzureBlobBackend::list_containers(self, continuation).await
+    }
+
+    async fn list_blobs(
+        &self,
+        _ctx: &Ctx,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>> {
+        AzureBlobBackend::list_blobs(self, container, prefix, delimiter, continuation).await
+    }
+
+    async fn read_blob(
+        &self,
+        _ctx: &Ctx,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream> {
+        AzureBlobBackend::read_blob(self, path, range).await
+    }
+
+    async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult> {
+        AzureBlobBackend::write_blob(self, ctx, path, body, opts).await
+    }
+
+    async fn delete_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        opts: DeleteOpts,
+    ) -> crate::Result<()> {
+        AzureBlobBackend::delete_blob(self, ctx, path, opts).await
+    }
+}

--- a/crates/arkived-core/src/backend/azure/mod.rs
+++ b/crates/arkived-core/src/backend/azure/mod.rs
@@ -1,0 +1,83 @@
+//! Azure Blob Storage + ADLS Gen2 backend, hand-rolled on `reqwest`.
+//!
+//! The backend consumes a [`ResolvedCredential`] from the auth layer and
+//! dispatches requests via [`http::HttpPipeline`] which applies the
+//! appropriate auth bridge (SharedKey HMAC signing, SAS URL decoration,
+//! Entra bearer token, or anonymous).
+//!
+//! See [`crate::backend`](crate::backend) for shared types.
+
+pub(crate) mod auth_bridge;
+pub(crate) mod error;
+pub(crate) mod http;
+pub(crate) mod models;
+pub(crate) mod ops;
+pub(crate) mod retry;
+pub(crate) mod xml;
+
+use crate::auth::ResolvedCredential;
+use std::sync::Arc;
+
+/// Azure Blob / ADLS Gen2 backend.
+///
+/// Construct via [`AzureBlobBackend::new`]. Methods map 1:1 to Azure REST
+/// verbs (`list_containers`, `list_blobs`, `read_blob`, `write_blob`,
+/// `delete_blob`).
+#[derive(Clone)]
+#[allow(dead_code)] // Fields used by ops impls in Tasks 9–13.
+pub struct AzureBlobBackend {
+    /// Account blob endpoint URL (no trailing slash), e.g.
+    /// `https://acme.blob.core.windows.net`.
+    pub(crate) endpoint: url::Url,
+    /// Credential to attach to every outgoing request.
+    pub(crate) credential: Arc<ResolvedCredential>,
+    /// Shared reqwest client for connection reuse.
+    pub(crate) http: reqwest::Client,
+}
+
+impl std::fmt::Debug for AzureBlobBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzureBlobBackend")
+            .field("endpoint", &self.endpoint.as_str())
+            .field("credential", &self.credential.kind())
+            .finish()
+    }
+}
+
+impl AzureBlobBackend {
+    /// Construct a backend from an endpoint URL and resolved credential.
+    pub fn new(endpoint: url::Url, credential: ResolvedCredential) -> crate::Result<Self> {
+        Ok(Self {
+            endpoint,
+            credential: Arc::new(credential),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    /// The configured blob endpoint URL.
+    pub fn endpoint(&self) -> &url::Url {
+        &self.endpoint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ResolvedCredential;
+
+    #[test]
+    fn construction_succeeds() {
+        let url = url::Url::parse("https://acme.blob.core.windows.net").unwrap();
+        let b = AzureBlobBackend::new(url.clone(), ResolvedCredential::Anonymous).unwrap();
+        assert_eq!(b.endpoint(), &url);
+    }
+
+    #[test]
+    fn debug_hides_credential_contents() {
+        let url = url::Url::parse("https://acme.blob.core.windows.net").unwrap();
+        let b = AzureBlobBackend::new(url, ResolvedCredential::Anonymous).unwrap();
+        let dbg = format!("{b:?}");
+        assert!(dbg.contains("AzureBlobBackend"));
+        assert!(dbg.contains("acme.blob.core.windows.net"));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/models.rs
+++ b/crates/arkived-core/src/backend/azure/models.rs
@@ -44,6 +44,9 @@ pub(crate) struct ContainerProperties {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct ListBlobsResult {
+    /// Echo of the prefix filter the server applied. Not surfaced through
+    /// the public API since the caller already knows what they requested.
+    #[allow(dead_code)]
     #[serde(rename = "Prefix", default)]
     pub prefix: Option<String>,
     #[serde(rename = "Blobs", default)]

--- a/crates/arkived-core/src/backend/azure/models.rs
+++ b/crates/arkived-core/src/backend/azure/models.rs
@@ -1,0 +1,1 @@
+//! XML DTOs for Azure REST requests/responses. Filled in Task 8.

--- a/crates/arkived-core/src/backend/azure/models.rs
+++ b/crates/arkived-core/src/backend/azure/models.rs
@@ -1,1 +1,167 @@
-//! XML DTOs for Azure REST requests/responses. Filled in Task 8.
+//! XML DTOs for Azure Blob REST responses.
+//!
+//! These are the wire-level types; they're converted to the public
+//! [`Container`](crate::backend::Container) / [`BlobEntry`](crate::backend::BlobEntry)
+//! types in each op module.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ListContainersResult {
+    #[serde(rename = "Containers", default)]
+    pub containers: ContainerList,
+    #[serde(rename = "NextMarker", default)]
+    pub next_marker: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ContainerList {
+    #[serde(rename = "Container", default)]
+    pub items: Vec<XmlContainer>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct XmlContainer {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Properties", default)]
+    pub properties: ContainerProperties,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ContainerProperties {
+    #[serde(rename = "Last-Modified", default)]
+    pub last_modified: Option<String>,
+    #[serde(rename = "Etag", default)]
+    pub etag: Option<String>,
+    #[serde(rename = "LeaseStatus", default)]
+    pub lease_status: Option<String>,
+    #[serde(rename = "LeaseState", default)]
+    pub lease_state: Option<String>,
+    #[serde(rename = "PublicAccess", default)]
+    pub public_access: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ListBlobsResult {
+    #[serde(rename = "Prefix", default)]
+    pub prefix: Option<String>,
+    #[serde(rename = "Blobs", default)]
+    pub blobs: BlobList,
+    #[serde(rename = "NextMarker", default)]
+    pub next_marker: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct BlobList {
+    #[serde(rename = "Blob", default)]
+    pub items: Vec<XmlBlob>,
+    #[serde(rename = "BlobPrefix", default)]
+    pub prefixes: Vec<XmlBlobPrefix>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct XmlBlob {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Properties", default)]
+    pub properties: BlobProperties,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct BlobProperties {
+    #[serde(rename = "Last-Modified", default)]
+    pub last_modified: Option<String>,
+    #[serde(rename = "Etag", default)]
+    pub etag: Option<String>,
+    #[serde(rename = "Content-Length", default)]
+    pub content_length: Option<u64>,
+    #[serde(rename = "Content-Type", default)]
+    pub content_type: Option<String>,
+    #[serde(rename = "BlobType", default)]
+    pub blob_type: Option<String>,
+    #[serde(rename = "AccessTier", default)]
+    pub access_tier: Option<String>,
+    #[serde(rename = "LeaseState", default)]
+    pub lease_state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct XmlBlobPrefix {
+    #[serde(rename = "Name")]
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::azure::xml::parse_xml;
+
+    const LIST_CONTAINERS: &str = r#"<?xml version="1.0"?>
+<EnumerationResults>
+  <Containers>
+    <Container>
+      <Name>alpha</Name>
+      <Properties>
+        <Last-Modified>Mon, 21 Apr 2026 12:00:00 GMT</Last-Modified>
+        <Etag>0x8DC</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>beta</Name>
+      <Properties>
+        <PublicAccess>blob</PublicAccess>
+      </Properties>
+    </Container>
+  </Containers>
+  <NextMarker/>
+</EnumerationResults>"#;
+
+    #[test]
+    fn parse_list_containers() {
+        let r: ListContainersResult = parse_xml(LIST_CONTAINERS).unwrap();
+        assert_eq!(r.containers.items.len(), 2);
+        assert_eq!(r.containers.items[0].name, "alpha");
+        assert_eq!(
+            r.containers.items[0].properties.lease_state.as_deref(),
+            Some("available")
+        );
+        assert_eq!(
+            r.containers.items[1].properties.public_access.as_deref(),
+            Some("blob")
+        );
+    }
+
+    const LIST_BLOBS: &str = r#"<?xml version="1.0"?>
+<EnumerationResults ContainerName="device-twins">
+  <Prefix>sync/</Prefix>
+  <Blobs>
+    <Blob>
+      <Name>sync/part-00001.parquet</Name>
+      <Properties>
+        <Last-Modified>Mon, 21 Apr 2026 11:11:42 GMT</Last-Modified>
+        <Etag>0x8DC7A9F</Etag>
+        <Content-Length>14221000</Content-Length>
+        <Content-Type>application/octet-stream</Content-Type>
+        <BlobType>BlockBlob</BlobType>
+        <AccessTier>Hot</AccessTier>
+        <LeaseState>available</LeaseState>
+      </Properties>
+    </Blob>
+    <BlobPrefix><Name>sync/2026-04/</Name></BlobPrefix>
+  </Blobs>
+  <NextMarker>AAAA</NextMarker>
+</EnumerationResults>"#;
+
+    #[test]
+    fn parse_list_blobs() {
+        let r: ListBlobsResult = parse_xml(LIST_BLOBS).unwrap();
+        assert_eq!(r.blobs.items.len(), 1);
+        assert_eq!(r.blobs.prefixes.len(), 1);
+        assert_eq!(r.blobs.items[0].properties.content_length, Some(14221000));
+        assert_eq!(r.blobs.prefixes[0].name, "sync/2026-04/");
+        assert_eq!(r.next_marker.as_deref(), Some("AAAA"));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/ops/delete_blob.rs
+++ b/crates/arkived-core/src/backend/azure/ops/delete_blob.rs
@@ -32,7 +32,7 @@ impl AzureBlobBackend {
             )
             .await;
         match decision {
-            PolicyDecision::Allow | PolicyDecision::AllowAlways { .. } => {}
+            PolicyDecision::Allow | PolicyDecision::AllowAlways => {}
             PolicyDecision::Deny(reason) => return Err(Error::PolicyDenied(reason)),
         }
 
@@ -93,8 +93,8 @@ mod tests {
     async fn deny_all_policy_short_circuits_before_http() {
         let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
         let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
-        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
-            .with_progress(Arc::new(NoopSink));
+        let ctx =
+            Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy)).with_progress(Arc::new(NoopSink));
 
         let err = backend
             .delete_blob(&ctx, &BlobPath::new("c", "b"), DeleteOpts::default())

--- a/crates/arkived-core/src/backend/azure/ops/delete_blob.rs
+++ b/crates/arkived-core/src/backend/azure/ops/delete_blob.rs
@@ -1,0 +1,105 @@
+//! `DELETE /{container}/{blob}` — policy-gated blob deletion.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobPath, DeleteOpts};
+use crate::policy::{Action, ActionContext, PolicyDecision};
+use crate::{Ctx, Error};
+use reqwest::Method;
+
+impl AzureBlobBackend {
+    /// Delete a blob. Calls `ctx.policy.confirm("delete_blob", ...)` before
+    /// any HTTP is sent. Denies the operation on `Deny`.
+    pub async fn delete_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        opts: DeleteOpts,
+    ) -> crate::Result<()> {
+        let decision = ctx
+            .policy
+            .confirm(
+                &Action {
+                    verb: "delete_blob".into(),
+                    target: format!("{}/{}", path.container, path.blob),
+                    summary: format!("delete {}/{}", path.container, path.blob),
+                    reversible: true,
+                },
+                &ActionContext {
+                    item_count: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await;
+        match decision {
+            PolicyDecision::Allow | PolicyDecision::AllowAlways { .. } => {}
+            PolicyDecision::Deny(reason) => return Err(Error::PolicyDenied(reason)),
+        }
+
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}/{}", path.container, path.blob));
+        url.set_query(None);
+
+        let mut headers = Vec::<(String, String)>::new();
+        if opts.include_snapshots {
+            headers.push(("x-ms-delete-snapshots".into(), "include".into()));
+        }
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let _ = pipeline
+            .send(RequestTemplate {
+                method: Method::DELETE,
+                url,
+                headers,
+                body: Body::Empty,
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ResolvedCredential;
+    use crate::backend::azure::AzureBlobBackend;
+    use crate::policy::DenyAllPolicy;
+    use crate::progress::NoopSink;
+    use crate::types::{AuthKind, ResourceKind};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct FakeAuth;
+    #[async_trait]
+    impl crate::auth::AuthProvider for FakeAuth {
+        fn kind(&self) -> AuthKind {
+            AuthKind::Anonymous
+        }
+        fn display_name(&self) -> &str {
+            "fake"
+        }
+        async fn resolve(&self) -> crate::Result<ResolvedCredential> {
+            Ok(ResolvedCredential::Anonymous)
+        }
+        fn supports(&self, _: ResourceKind) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_all_policy_short_circuits_before_http() {
+        let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
+        let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
+        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
+            .with_progress(Arc::new(NoopSink));
+
+        let err = backend
+            .delete_blob(&ctx, &BlobPath::new("c", "b"), DeleteOpts::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PolicyDenied(_)));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/ops/list_blobs.rs
+++ b/crates/arkived-core/src/backend/azure/ops/list_blobs.rs
@@ -1,0 +1,89 @@
+//! `GET /{container}?restype=container&comp=list` — list blobs in a container.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::models::ListBlobsResult;
+use crate::backend::azure::xml::parse_xml;
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobEntry, Page};
+use reqwest::Method;
+use time::format_description::well_known::Rfc2822;
+use time::OffsetDateTime;
+
+impl AzureBlobBackend {
+    /// GET /{container}?restype=container&comp=list — return a page of blobs.
+    ///
+    /// - `prefix`: only list blobs whose name starts with this string.
+    /// - `delimiter`: if `Some("/")`, returns virtual directory prefixes as
+    ///   [`BlobEntry::Prefix`] entries instead of full blob names.
+    /// - `continuation`: opaque marker from a prior call's
+    ///   [`Page::continuation`].
+    pub async fn list_blobs(
+        &self,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>> {
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}", container));
+        let mut query = String::from("restype=container&comp=list");
+        if let Some(p) = prefix {
+            query.push_str(&format!("&prefix={}", urlencoding::encode(p)));
+        }
+        if let Some(d) = delimiter {
+            query.push_str(&format!("&delimiter={}", urlencoding::encode(d)));
+        }
+        if let Some(m) = &continuation {
+            query.push_str(&format!("&marker={}", urlencoding::encode(m)));
+        }
+        url.set_query(Some(&query));
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await?;
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| crate::Error::Backend(format!("read list_blobs body: {e}")))?;
+        let parsed: ListBlobsResult = parse_xml(&body)?;
+
+        let mut items: Vec<BlobEntry> = Vec::new();
+
+        for b in parsed.blobs.items {
+            items.push(BlobEntry::Blob {
+                name: b.name,
+                size: b.properties.content_length.unwrap_or(0),
+                blob_type: b
+                    .properties
+                    .blob_type
+                    .unwrap_or_else(|| "BlockBlob".into()),
+                tier: b.properties.access_tier,
+                etag: b.properties.etag,
+                content_type: b.properties.content_type,
+                last_modified: b
+                    .properties
+                    .last_modified
+                    .as_deref()
+                    .and_then(|s| OffsetDateTime::parse(s, &Rfc2822).ok()),
+                lease_state: b.properties.lease_state,
+            });
+        }
+        for pfx in parsed.blobs.prefixes {
+            items.push(BlobEntry::Prefix { name: pfx.name });
+        }
+
+        Ok(Page {
+            items,
+            continuation: parsed.next_marker.filter(|s| !s.is_empty()),
+        })
+    }
+}

--- a/crates/arkived-core/src/backend/azure/ops/list_blobs.rs
+++ b/crates/arkived-core/src/backend/azure/ops/list_blobs.rs
@@ -25,7 +25,7 @@ impl AzureBlobBackend {
         continuation: Option<String>,
     ) -> crate::Result<Page<BlobEntry>> {
         let mut url = self.endpoint.clone();
-        url.set_path(&format!("/{}", container));
+        url.set_path(&format!("/{container}"));
         let mut query = String::from("restype=container&comp=list");
         if let Some(p) = prefix {
             query.push_str(&format!("&prefix={}", urlencoding::encode(p)));
@@ -62,10 +62,7 @@ impl AzureBlobBackend {
             items.push(BlobEntry::Blob {
                 name: b.name,
                 size: b.properties.content_length.unwrap_or(0),
-                blob_type: b
-                    .properties
-                    .blob_type
-                    .unwrap_or_else(|| "BlockBlob".into()),
+                blob_type: b.properties.blob_type.unwrap_or_else(|| "BlockBlob".into()),
                 tier: b.properties.access_tier,
                 etag: b.properties.etag,
                 content_type: b.properties.content_type,

--- a/crates/arkived-core/src/backend/azure/ops/list_containers.rs
+++ b/crates/arkived-core/src/backend/azure/ops/list_containers.rs
@@ -1,0 +1,68 @@
+//! `GET /?comp=list` — list containers.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::models::ListContainersResult;
+use crate::backend::azure::xml::parse_xml;
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{Container, Page};
+use reqwest::Method;
+use time::format_description::well_known::Rfc2822;
+use time::OffsetDateTime;
+
+impl AzureBlobBackend {
+    /// GET /?comp=list — return a page of containers.
+    pub async fn list_containers(
+        &self,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>> {
+        let mut url = self.endpoint.clone();
+        // Service-level list: path is "/", query comp=list.
+        url.set_path("/");
+        let mut query = String::from("comp=list");
+        if let Some(marker) = &continuation {
+            query.push_str(&format!("&marker={}", urlencoding::encode(marker)));
+        }
+        url.set_query(Some(&query));
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await?;
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| crate::Error::Backend(format!("read list_containers body: {e}")))?;
+        let parsed: ListContainersResult = parse_xml(&body)?;
+
+        let items: Vec<Container> = parsed
+            .containers
+            .items
+            .into_iter()
+            .map(|x| Container {
+                name: x.name,
+                last_modified: x
+                    .properties
+                    .last_modified
+                    .as_deref()
+                    .and_then(|s| OffsetDateTime::parse(s, &Rfc2822).ok()),
+                etag: x.properties.etag,
+                lease_status: x.properties.lease_status,
+                lease_state: x.properties.lease_state,
+                public_access: x.properties.public_access,
+            })
+            .collect();
+
+        Ok(Page {
+            items,
+            continuation: parsed.next_marker.filter(|s| !s.is_empty()),
+        })
+    }
+}

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -1,1 +1,3 @@
-//! Per-REST-verb implementations. Submodules land in Tasks 9–13.
+//! Per-REST-verb implementations.
+
+pub(crate) mod list_containers;

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -3,3 +3,4 @@
 pub(crate) mod list_containers;
 pub(crate) mod list_blobs;
 pub(crate) mod read_blob;
+pub(crate) mod write_blob;

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod list_containers;
 pub(crate) mod list_blobs;
 pub(crate) mod read_blob;
 pub(crate) mod write_blob;
+pub(crate) mod delete_blob;

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -1,3 +1,4 @@
 //! Per-REST-verb implementations.
 
 pub(crate) mod list_containers;
+pub(crate) mod list_blobs;

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -2,3 +2,4 @@
 
 pub(crate) mod list_containers;
 pub(crate) mod list_blobs;
+pub(crate) mod read_blob;

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -1,7 +1,7 @@
 //! Per-REST-verb implementations.
 
-pub(crate) mod list_containers;
+pub(crate) mod delete_blob;
 pub(crate) mod list_blobs;
+pub(crate) mod list_containers;
 pub(crate) mod read_blob;
 pub(crate) mod write_blob;
-pub(crate) mod delete_blob;

--- a/crates/arkived-core/src/backend/azure/ops/mod.rs
+++ b/crates/arkived-core/src/backend/azure/ops/mod.rs
@@ -1,0 +1,1 @@
+//! Per-REST-verb implementations. Submodules land in Tasks 9–13.

--- a/crates/arkived-core/src/backend/azure/ops/read_blob.rs
+++ b/crates/arkived-core/src/backend/azure/ops/read_blob.rs
@@ -1,0 +1,49 @@
+//! `GET /{container}/{blob}` — read a blob as a byte stream.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobPath, ByteStream, Range};
+use crate::Error;
+use futures::stream::{StreamExt, TryStreamExt};
+use reqwest::Method;
+
+impl AzureBlobBackend {
+    /// Stream a blob's bytes. Supports HTTP ranged reads via `range`.
+    pub async fn read_blob(
+        &self,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream> {
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}/{}", path.container, path.blob));
+        url.set_query(None);
+
+        let mut headers = Vec::<(String, String)>::new();
+        if let Some(r) = range {
+            let range_header = match r.end {
+                Some(end) => format!("bytes={}-{}", r.start, end),
+                None => format!("bytes={}-", r.start),
+            };
+            headers.push(("x-ms-range".into(), range_header));
+        }
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers,
+                body: Body::Empty,
+            })
+            .await?;
+
+        let stream = resp
+            .bytes_stream()
+            .map_err(|e| Error::NetworkTransient(format!("read_blob stream: {e}")))
+            .boxed();
+        Ok(stream)
+    }
+}

--- a/crates/arkived-core/src/backend/azure/ops/write_blob.rs
+++ b/crates/arkived-core/src/backend/azure/ops/write_blob.rs
@@ -156,4 +156,75 @@ mod tests {
         let err = collect_bytes(s, 1000).await.unwrap_err();
         assert!(matches!(err, Error::Backend(_)));
     }
+
+    use crate::auth::ResolvedCredential;
+    use crate::backend::AzureBlobBackend;
+    use crate::policy::DenyAllPolicy;
+    use crate::progress::NoopSink;
+    use crate::types::{AuthKind, ResourceKind};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct FakeAuth;
+    #[async_trait]
+    impl crate::auth::AuthProvider for FakeAuth {
+        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
+        fn display_name(&self) -> &str { "fake" }
+        async fn resolve(&self) -> crate::Result<ResolvedCredential> {
+            Ok(ResolvedCredential::Anonymous)
+        }
+        fn supports(&self, _: ResourceKind) -> bool { true }
+    }
+
+    #[tokio::test]
+    async fn overwrite_with_deny_all_policy_blocks_before_http() {
+        let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
+        let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
+        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
+            .with_progress(Arc::new(NoopSink));
+
+        let chunks: Vec<crate::Result<Bytes>> = vec![Ok(Bytes::from("data"))];
+        let stream = futures::stream::iter(chunks).boxed();
+
+        let err = backend
+            .write_blob(
+                &ctx,
+                &BlobPath::new("c", "b"),
+                stream,
+                WriteOpts {
+                    overwrite: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PolicyDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn non_overwrite_write_does_not_invoke_policy() {
+        // With overwrite=false we never call policy.confirm, so DenyAllPolicy
+        // is irrelevant. This test only verifies the code path compiles and
+        // runs up to the HTTP call (which will fail on the unreachable URL,
+        // but that's a NetworkTransient rather than a PolicyDenied).
+        let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
+        let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
+        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
+            .with_progress(Arc::new(NoopSink));
+
+        let chunks: Vec<crate::Result<Bytes>> = vec![Ok(Bytes::from("data"))];
+        let stream = futures::stream::iter(chunks).boxed();
+
+        let err = backend
+            .write_blob(
+                &ctx,
+                &BlobPath::new("c", "b"),
+                stream,
+                WriteOpts { overwrite: false, ..Default::default() },
+            )
+            .await
+            .unwrap_err();
+        // Should NOT be PolicyDenied — we skipped the policy check.
+        assert!(!matches!(err, Error::PolicyDenied(_)));
+    }
 }

--- a/crates/arkived-core/src/backend/azure/ops/write_blob.rs
+++ b/crates/arkived-core/src/backend/azure/ops/write_blob.rs
@@ -1,0 +1,159 @@
+//! `PUT /{container}/{blob}` — single-shot block-blob upload.
+//!
+//! Azure allows block blobs up to 5000 MiB via a single `PUT Blob` request.
+//! For now we buffer the stream into memory before uploading. Chunked
+//! (Put Block + Put Block List) flows are a Backend-Depth plan follow-up.
+//!
+//! **Policy gating:** calls `ctx.policy.confirm(...)` when the blob would be
+//! overwritten.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobPath, ByteStream, WriteOpts, WriteResult};
+use crate::policy::{Action, ActionContext, PolicyDecision};
+use crate::{Ctx, Error};
+use bytes::{Bytes, BytesMut};
+use futures::stream::StreamExt;
+use reqwest::Method;
+use time::format_description::well_known::Rfc2822;
+use time::OffsetDateTime;
+
+impl AzureBlobBackend {
+    /// Upload a block blob in one request.
+    ///
+    /// If `opts.overwrite` is false and the blob exists, returns
+    /// [`Error::Conflict`]. If overwrite is true AND the blob exists, this
+    /// method first calls `ctx.policy.confirm("overwrite_blob", ...)`.
+    pub async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult> {
+        // Buffer the stream. For v0.1.0 we cap bodies at 256 MiB in memory;
+        // larger uploads get the chunked flow in the depth plan.
+        const MAX_INLINE_BYTES: usize = 256 * 1024 * 1024;
+        let bytes = collect_bytes(body, MAX_INLINE_BYTES).await?;
+
+        // Policy gate on potential overwrite.
+        if opts.overwrite {
+            let decision = ctx
+                .policy
+                .confirm(
+                    &Action {
+                        verb: "overwrite_blob".into(),
+                        target: format!("{}/{}", path.container, path.blob),
+                        summary: format!(
+                            "overwrite {}/{} with {} bytes",
+                            path.container,
+                            path.blob,
+                            bytes.len()
+                        ),
+                        reversible: false,
+                    },
+                    &ActionContext {
+                        item_count: Some(1),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            match decision {
+                PolicyDecision::Allow | PolicyDecision::AllowAlways { .. } => {}
+                PolicyDecision::Deny(reason) => return Err(Error::PolicyDenied(reason)),
+            }
+        }
+
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}/{}", path.container, path.blob));
+        url.set_query(None);
+
+        let mut headers: Vec<(String, String)> = vec![
+            ("x-ms-blob-type".into(), "BlockBlob".into()),
+            ("content-length".into(), bytes.len().to_string()),
+        ];
+        if let Some(ct) = &opts.content_type {
+            headers.push(("content-type".into(), ct.clone()));
+        } else {
+            headers.push(("content-type".into(), "application/octet-stream".into()));
+        }
+        if !opts.overwrite {
+            headers.push(("if-none-match".into(), "*".into()));
+        }
+        if let Some(etag) = &opts.if_match {
+            headers.push(("if-match".into(), etag.clone()));
+        }
+        for (k, v) in &opts.metadata {
+            headers.push((format!("x-ms-meta-{k}"), v.clone()));
+        }
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::PUT,
+                url,
+                headers,
+                body: Body::Bytes(bytes),
+            })
+            .await?;
+
+        let etag = resp
+            .headers()
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let last_modified = resp
+            .headers()
+            .get("last-modified")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| OffsetDateTime::parse(s, &Rfc2822).ok());
+
+        Ok(WriteResult {
+            etag,
+            last_modified,
+            blob_type: "BlockBlob".into(),
+        })
+    }
+}
+
+async fn collect_bytes(mut stream: ByteStream, max: usize) -> crate::Result<Bytes> {
+    let mut buf = BytesMut::new();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk?;
+        if buf.len() + bytes.len() > max {
+            return Err(Error::Backend(format!(
+                "upload body exceeds {max} bytes (chunked upload lands in Backend-Depth plan)"
+            )));
+        }
+        buf.extend_from_slice(&bytes);
+    }
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn collect_bytes_returns_full_body() {
+        let chunks: Vec<crate::Result<Bytes>> =
+            vec![Ok(Bytes::from("hello ")), Ok(Bytes::from("world"))];
+        let s = stream::iter(chunks).boxed();
+        let body = collect_bytes(s, 1024).await.unwrap();
+        assert_eq!(&body[..], b"hello world");
+    }
+
+    #[tokio::test]
+    async fn collect_bytes_errors_above_limit() {
+        let chunks: Vec<crate::Result<Bytes>> =
+            vec![Ok(Bytes::from(vec![0u8; 600])), Ok(Bytes::from(vec![0u8; 600]))];
+        let s = stream::iter(chunks).boxed();
+        let err = collect_bytes(s, 1000).await.unwrap_err();
+        assert!(matches!(err, Error::Backend(_)));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/ops/write_blob.rs
+++ b/crates/arkived-core/src/backend/azure/ops/write_blob.rs
@@ -59,7 +59,7 @@ impl AzureBlobBackend {
                 )
                 .await;
             match decision {
-                PolicyDecision::Allow | PolicyDecision::AllowAlways { .. } => {}
+                PolicyDecision::Allow | PolicyDecision::AllowAlways => {}
                 PolicyDecision::Deny(reason) => return Err(Error::PolicyDenied(reason)),
             }
         }
@@ -150,8 +150,10 @@ mod tests {
 
     #[tokio::test]
     async fn collect_bytes_errors_above_limit() {
-        let chunks: Vec<crate::Result<Bytes>> =
-            vec![Ok(Bytes::from(vec![0u8; 600])), Ok(Bytes::from(vec![0u8; 600]))];
+        let chunks: Vec<crate::Result<Bytes>> = vec![
+            Ok(Bytes::from(vec![0u8; 600])),
+            Ok(Bytes::from(vec![0u8; 600])),
+        ];
         let s = stream::iter(chunks).boxed();
         let err = collect_bytes(s, 1000).await.unwrap_err();
         assert!(matches!(err, Error::Backend(_)));
@@ -168,20 +170,26 @@ mod tests {
     struct FakeAuth;
     #[async_trait]
     impl crate::auth::AuthProvider for FakeAuth {
-        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
-        fn display_name(&self) -> &str { "fake" }
+        fn kind(&self) -> AuthKind {
+            AuthKind::Anonymous
+        }
+        fn display_name(&self) -> &str {
+            "fake"
+        }
         async fn resolve(&self) -> crate::Result<ResolvedCredential> {
             Ok(ResolvedCredential::Anonymous)
         }
-        fn supports(&self, _: ResourceKind) -> bool { true }
+        fn supports(&self, _: ResourceKind) -> bool {
+            true
+        }
     }
 
     #[tokio::test]
     async fn overwrite_with_deny_all_policy_blocks_before_http() {
         let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
         let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
-        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
-            .with_progress(Arc::new(NoopSink));
+        let ctx =
+            Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy)).with_progress(Arc::new(NoopSink));
 
         let chunks: Vec<crate::Result<Bytes>> = vec![Ok(Bytes::from("data"))];
         let stream = futures::stream::iter(chunks).boxed();
@@ -209,8 +217,8 @@ mod tests {
         // but that's a NetworkTransient rather than a PolicyDenied).
         let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
         let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
-        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
-            .with_progress(Arc::new(NoopSink));
+        let ctx =
+            Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy)).with_progress(Arc::new(NoopSink));
 
         let chunks: Vec<crate::Result<Bytes>> = vec![Ok(Bytes::from("data"))];
         let stream = futures::stream::iter(chunks).boxed();
@@ -220,7 +228,10 @@ mod tests {
                 &ctx,
                 &BlobPath::new("c", "b"),
                 stream,
-                WriteOpts { overwrite: false, ..Default::default() },
+                WriteOpts {
+                    overwrite: false,
+                    ..Default::default()
+                },
             )
             .await
             .unwrap_err();

--- a/crates/arkived-core/src/backend/azure/retry.rs
+++ b/crates/arkived-core/src/backend/azure/retry.rs
@@ -1,1 +1,9 @@
 //! Exponential backoff with jitter. Filled in Task 7.
+
+pub(crate) async fn with_retries<F, Fut, T>(mut f: F) -> crate::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = crate::Result<T>>,
+{
+    f().await
+}

--- a/crates/arkived-core/src/backend/azure/retry.rs
+++ b/crates/arkived-core/src/backend/azure/retry.rs
@@ -1,0 +1,1 @@
+//! Exponential backoff with jitter. Filled in Task 7.

--- a/crates/arkived-core/src/backend/azure/retry.rs
+++ b/crates/arkived-core/src/backend/azure/retry.rs
@@ -68,9 +68,12 @@ fn fastrand_u64(max_exclusive: u64) -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos() as u64 | ((d.as_secs() as u64) << 32))
+        .map(|d| d.subsec_nanos() as u64 | (d.as_secs() << 32))
         .unwrap_or(0);
-    (nanos.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407)) % max_exclusive
+    (nanos
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407))
+        % max_exclusive
 }
 
 #[cfg(test)]
@@ -107,7 +110,9 @@ mod tests {
             let a = a2.clone();
             async move {
                 a.fetch_add(1, Ordering::SeqCst);
-                Err(Error::NotFound { resource: "x".into() })
+                Err(Error::NotFound {
+                    resource: "x".into(),
+                })
             }
         })
         .await;

--- a/crates/arkived-core/src/backend/azure/retry.rs
+++ b/crates/arkived-core/src/backend/azure/retry.rs
@@ -1,9 +1,133 @@
-//! Exponential backoff with jitter. Filled in Task 7.
+//! Retry policy for transient errors.
+//!
+//! Retries are triggered by `Error::Throttled`, `Error::NetworkTransient`,
+//! and `Error::Backend(...)` where the message indicates a 5xx (we treat
+//! all Backend errors as retryable for simplicity — 5xx responses already
+//! map there via `map_rest_error`).
+//!
+//! Schedule: exponential backoff with full jitter, capped at 30s, max
+//! 8 attempts. `Throttled { retry_after }` respects the server's
+//! suggested delay as a lower bound.
 
+use crate::Error;
+use std::time::Duration;
+
+/// Max retry attempts (including the first).
+pub(crate) const MAX_ATTEMPTS: usize = 8;
+
+/// Maximum backoff cap.
+pub(crate) const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Run `f` with exponential-backoff retries on transient errors.
 pub(crate) async fn with_retries<F, Fut, T>(mut f: F) -> crate::Result<T>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = crate::Result<T>>,
 {
-    f().await
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) if !is_retryable(&e) || attempt >= MAX_ATTEMPTS => return Err(e),
+            Err(e) => {
+                let delay = backoff_for(attempt, &e);
+                tracing::debug!(attempt, ?delay, ?e, "retryable error; backing off");
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+fn is_retryable(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::Throttled { .. } | Error::NetworkTransient(_) | Error::Backend(_)
+    )
+}
+
+fn backoff_for(attempt: usize, e: &Error) -> Duration {
+    // Respect server-directed retry-after if present.
+    if let Error::Throttled { retry_after } = e {
+        return (*retry_after).min(MAX_BACKOFF);
+    }
+
+    // Exponential with full jitter. base = 100ms * 2^(attempt-1), capped.
+    let base_ms: u64 = 100u64.saturating_mul(1u64 << (attempt.saturating_sub(1).min(10)));
+    let capped = base_ms.min(MAX_BACKOFF.as_millis() as u64);
+    // Full jitter: uniform in [0, capped].
+    let jittered = fastrand_u64(capped);
+    Duration::from_millis(jittered)
+}
+
+fn fastrand_u64(max_exclusive: u64) -> u64 {
+    if max_exclusive == 0 {
+        return 0;
+    }
+    // Tiny LCG keyed off nanosecond clock — good enough for retry jitter.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64 | ((d.as_secs() as u64) << 32))
+        .unwrap_or(0);
+    (nanos.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407)) % max_exclusive
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn retries_on_transient_then_succeeds() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a2 = attempts.clone();
+        let out: crate::Result<i32> = with_retries(|| {
+            let a = a2.clone();
+            async move {
+                let n = a.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(Error::NetworkTransient("flaky".into()))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(out.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_error_fails_fast() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a2 = attempts.clone();
+        let out: crate::Result<i32> = with_retries(|| {
+            let a = a2.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                Err(Error::NotFound { resource: "x".into() })
+            }
+        })
+        .await;
+        assert!(matches!(out, Err(Error::NotFound { .. })));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_attempts() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a2 = attempts.clone();
+        let out: crate::Result<i32> = with_retries(|| {
+            let a = a2.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                Err(Error::NetworkTransient("always".into()))
+            }
+        })
+        .await;
+        assert!(matches!(out, Err(Error::NetworkTransient(_))));
+        assert_eq!(attempts.load(Ordering::SeqCst), MAX_ATTEMPTS);
+    }
 }

--- a/crates/arkived-core/src/backend/azure/xml.rs
+++ b/crates/arkived-core/src/backend/azure/xml.rs
@@ -1,1 +1,35 @@
-//! Shared XML deserialization helpers. Filled in Task 8.
+//! Shared XML deserialization helpers for Azure REST responses.
+
+use crate::Error;
+use quick_xml::de::from_str;
+use serde::de::DeserializeOwned;
+
+/// Parse a response body as XML.
+pub(crate) fn parse_xml<T: DeserializeOwned>(body: &str) -> crate::Result<T> {
+    from_str(body).map_err(|e| Error::Backend(format!("parse xml: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Greeting {
+        #[serde(rename = "$text")]
+        text: String,
+    }
+
+    #[test]
+    fn round_trips_simple_xml() {
+        let doc = r#"<Greeting>hello</Greeting>"#;
+        let g: Greeting = parse_xml(doc).unwrap();
+        assert_eq!(g.text, "hello");
+    }
+
+    #[test]
+    fn malformed_becomes_backend_error() {
+        let err: crate::Result<Greeting> = parse_xml("<not xml>");
+        assert!(matches!(err, Err(Error::Backend(_))));
+    }
+}

--- a/crates/arkived-core/src/backend/azure/xml.rs
+++ b/crates/arkived-core/src/backend/azure/xml.rs
@@ -1,0 +1,1 @@
+//! Shared XML deserialization helpers. Filled in Task 8.

--- a/crates/arkived-core/src/backend/mod.rs
+++ b/crates/arkived-core/src/backend/mod.rs
@@ -24,7 +24,6 @@ use async_trait::async_trait;
 /// **Stability: internal.** This trait is `pub(crate)` and may change without
 /// notice. Do not implement or depend on it outside this crate.
 #[async_trait]
-#[allow(dead_code)] // Placeholder until ops impls are added in Tasks 9–13.
 pub(crate) trait StorageBackend: Send + Sync {
     /// Human-readable name (e.g. `"azure-blob"`).
     fn name(&self) -> &'static str;

--- a/crates/arkived-core/src/backend/mod.rs
+++ b/crates/arkived-core/src/backend/mod.rs
@@ -27,5 +27,7 @@ pub(crate) trait StorageBackend: Send + Sync {
     // before executing.
 }
 
+pub mod types;
+
 // Placeholder module — AzureBackend goes here in Stage 1:
 // pub(crate) mod azure;

--- a/crates/arkived-core/src/backend/mod.rs
+++ b/crates/arkived-core/src/backend/mod.rs
@@ -1,12 +1,22 @@
 //! Storage backend trait and implementations.
 //!
-//! This module is intentionally `pub(crate)`. The [`StorageBackend`] trait is an
-//! internal seam that will enable future backends (S3, GCS, etc.) to be added
-//! without restructuring the core. It is **not** part of the public API.
+//! The [`StorageBackend`] trait is intentionally `pub(crate)` — an internal
+//! seam that will enable future backends (S3, GCS, etc.) to be added without
+//! restructuring the core. It is **not** part of the public API.
 //!
-//! Public consumers should use the Azure-native functions exposed from the
-//! `arkived-core` crate root (to be added in Stage 1).
+//! Public consumers use [`azure::AzureBlobBackend`] directly; its method
+//! names and shapes are Azure-native.
 
+pub mod azure;
+pub mod types;
+
+#[allow(unused_imports)]
+pub use azure::AzureBlobBackend;
+pub use types::{
+    BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range, WriteOpts, WriteResult,
+};
+
+use crate::Ctx;
 use async_trait::async_trait;
 
 /// The internal storage backend abstraction.
@@ -14,20 +24,49 @@ use async_trait::async_trait;
 /// **Stability: internal.** This trait is `pub(crate)` and may change without
 /// notice. Do not implement or depend on it outside this crate.
 #[async_trait]
-#[allow(dead_code)] // Placeholder until the Backend plan fleshes out concrete impls.
+#[allow(dead_code)] // Placeholder until ops impls are added in Tasks 9–13.
 pub(crate) trait StorageBackend: Send + Sync {
-    /// A human-readable name for this backend (e.g. `"azure-blob"`).
+    /// Human-readable name (e.g. `"azure-blob"`).
     fn name(&self) -> &'static str;
 
-    // Full trait will be fleshed out in Stage 1:
-    //   list_containers, list_blobs, read_blob, write_blob,
-    //   delete_blob, generate_sas, etc.
-    //
-    // Each destructive method MUST route through the Policy layer
-    // before executing.
+    /// List containers under the storage account.
+    async fn list_containers(
+        &self,
+        ctx: &Ctx,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>>;
+
+    /// List blobs under a container with optional prefix and delimiter.
+    ///
+    /// When `delimiter` is `Some("/")`, virtual directories emerge as
+    /// [`BlobEntry::Prefix`] entries.
+    async fn list_blobs(
+        &self,
+        ctx: &Ctx,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>>;
+
+    /// Stream the bytes of a blob.
+    async fn read_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream>;
+
+    /// Upload a blob. Calls `ctx.policy.confirm` before overwriting an
+    /// existing blob.
+    async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult>;
+
+    /// Delete a blob. Always policy-gated.
+    async fn delete_blob(&self, ctx: &Ctx, path: &BlobPath, opts: DeleteOpts) -> crate::Result<()>;
 }
-
-pub mod types;
-
-// Placeholder module — AzureBackend goes here in Stage 1:
-// pub(crate) mod azure;

--- a/crates/arkived-core/src/backend/mod.rs
+++ b/crates/arkived-core/src/backend/mod.rs
@@ -23,7 +23,12 @@ use async_trait::async_trait;
 ///
 /// **Stability: internal.** This trait is `pub(crate)` and may change without
 /// notice. Do not implement or depend on it outside this crate.
+///
+/// `#[allow(dead_code)]` because only `AzureBlobBackend` implements it
+/// today; nothing yet consumes it via `dyn StorageBackend`. The trait
+/// exists as the seam a second backend (S3, GCS, …) will plug into.
 #[async_trait]
+#[allow(dead_code)]
 pub(crate) trait StorageBackend: Send + Sync {
     /// Human-readable name (e.g. `"azure-blob"`).
     fn name(&self) -> &'static str;

--- a/crates/arkived-core/src/backend/types.rs
+++ b/crates/arkived-core/src/backend/types.rs
@@ -1,0 +1,128 @@
+//! Shared request/response types for the backend layer.
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+/// A fully-qualified blob path: `(container, blob_name)`.
+///
+/// `blob_name` may contain `/` — the delimiter is just a name part, not a
+/// filesystem separator. ADLS Gen2 uses the same path as hierarchical name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobPath {
+    /// Container name (lowercase, letters/digits/hyphens, 3-63 chars).
+    pub container: String,
+    /// Blob name (slash-delimited for hierarchical paths).
+    pub blob: String,
+}
+
+impl BlobPath {
+    /// Construct from container + blob.
+    pub fn new(container: impl Into<String>, blob: impl Into<String>) -> Self {
+        Self { container: container.into(), blob: blob.into() }
+    }
+}
+
+/// A list page — items plus an optional continuation token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Page<T> {
+    /// Items on this page.
+    pub items: Vec<T>,
+    /// Continuation token for the next page, or `None` if this is the last.
+    pub continuation: Option<String>,
+}
+
+/// A container in the list-containers response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Container {
+    /// Container name.
+    pub name: String,
+    /// Last-modified timestamp.
+    pub last_modified: Option<OffsetDateTime>,
+    /// ETag.
+    pub etag: Option<String>,
+    /// Lease status (e.g. `"available"`, `"leased"`).
+    pub lease_status: Option<String>,
+    /// Lease state.
+    pub lease_state: Option<String>,
+    /// Public-access level (`"blob"`, `"container"`, or `None` for private).
+    pub public_access: Option<String>,
+}
+
+/// A blob or virtual directory entry in the list-blobs response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlobEntry {
+    /// A concrete blob.
+    Blob {
+        /// Full blob name.
+        name: String,
+        /// Size in bytes.
+        size: u64,
+        /// Blob type (`"BlockBlob"`, `"PageBlob"`, `"AppendBlob"`).
+        blob_type: String,
+        /// Access tier (`"Hot"`, `"Cool"`, `"Cold"`, `"Archive"`).
+        tier: Option<String>,
+        /// ETag.
+        etag: Option<String>,
+        /// Content-Type header from upload.
+        content_type: Option<String>,
+        /// Last-modified timestamp.
+        last_modified: Option<OffsetDateTime>,
+        /// Lease state.
+        lease_state: Option<String>,
+    },
+    /// A virtual directory prefix (emitted when `delimiter` is used).
+    Prefix {
+        /// The directory name (includes trailing delimiter).
+        name: String,
+    },
+}
+
+/// An HTTP byte range for `read_blob`.
+#[derive(Debug, Clone, Copy)]
+pub struct Range {
+    /// Start offset (inclusive).
+    pub start: u64,
+    /// End offset (inclusive). `None` = to end of blob.
+    pub end: Option<u64>,
+}
+
+/// Upload options.
+#[derive(Debug, Clone, Default)]
+pub struct WriteOpts {
+    /// If `false`, fail with `Conflict` when the blob already exists.
+    pub overwrite: bool,
+    /// Conditional: only overwrite if server ETag matches.
+    pub if_match: Option<String>,
+    /// Content-Type metadata to set on the blob.
+    pub content_type: Option<String>,
+    /// Arbitrary blob metadata headers.
+    pub metadata: HashMap<String, String>,
+    /// Max block size in bytes. Default 4 MiB.
+    pub block_size: Option<usize>,
+    /// Max parallel block uploads. Default 8.
+    pub max_parallelism: Option<usize>,
+}
+
+/// Result of a successful upload.
+#[derive(Debug, Clone)]
+pub struct WriteResult {
+    /// Server-assigned ETag.
+    pub etag: String,
+    /// Server-reported last-modified timestamp.
+    pub last_modified: Option<OffsetDateTime>,
+    /// Blob type (always `"BlockBlob"` for v0.1.0).
+    pub blob_type: String,
+}
+
+/// Delete options.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteOpts {
+    /// Delete snapshots too. Required if the blob has any (otherwise 409).
+    pub include_snapshots: bool,
+}
+
+/// Convenience alias for a byte-producing stream.
+pub type ByteStream = BoxStream<'static, crate::Result<Bytes>>;

--- a/crates/arkived-core/src/backend/types.rs
+++ b/crates/arkived-core/src/backend/types.rs
@@ -21,7 +21,10 @@ pub struct BlobPath {
 impl BlobPath {
     /// Construct from container + blob.
     pub fn new(container: impl Into<String>, blob: impl Into<String>) -> Self {
-        Self { container: container.into(), blob: blob.into() }
+        Self {
+            container: container.into(),
+            blob: blob.into(),
+        }
     }
 }
 

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -28,7 +28,7 @@ pub mod progress;
 pub mod store;
 pub mod types;
 
-pub(crate) mod backend;
+pub mod backend;
 
 // Re-export policy: the crate root surfaces top-level contracts (traits,
 // primary entry points, shared error types). Data-record types that only
@@ -38,6 +38,10 @@ pub(crate) mod backend;
 // module path (`arkived_core::store::SignIn` etc.) to keep the top-level namespace
 // focused.
 pub use auth::{AuthProvider, ResolvedCredential};
+pub use backend::{
+    AzureBlobBackend, BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range,
+    WriteOpts, WriteResult,
+};
 pub use config::{ArkivedConfig, ConfirmMode, OutputFormat};
 pub use ctx::{CancellationToken, Ctx};
 pub use error::{Error, Result};

--- a/crates/arkived-core/tests/azurite_crud.rs
+++ b/crates/arkived-core/tests/azurite_crud.rs
@@ -37,7 +37,10 @@ fn ctx() -> Ctx {
 #[ignore]
 async fn list_containers_against_azurite() {
     let b = backend().await;
-    let page = b.list_containers(None).await.expect("azurite must be running");
+    let page = b
+        .list_containers(None)
+        .await
+        .expect("azurite must be running");
     // We don't assert count — Azurite starts empty in CI but might have state on a dev box.
     println!("containers: {}", page.items.len());
 }
@@ -86,11 +89,19 @@ async fn full_write_read_delete_cycle() {
     assert_eq!(&collected[..], b"hello-arkived");
 
     // LIST
-    let page = b.list_blobs("arkivedci", None, None, None).await.expect("list_blobs");
-    assert!(page.items.iter().any(|e| matches!(e, BlobEntry::Blob { name, .. } if name == &path.blob)));
+    let page = b
+        .list_blobs("arkivedci", None, None, None)
+        .await
+        .expect("list_blobs");
+    assert!(page
+        .items
+        .iter()
+        .any(|e| matches!(e, BlobEntry::Blob { name, .. } if name == &path.blob)));
 
     // DELETE
-    b.delete_blob(&c, &path, DeleteOpts::default()).await.expect("delete_blob");
+    b.delete_blob(&c, &path, DeleteOpts::default())
+        .await
+        .expect("delete_blob");
 }
 
 /// Create a container if it doesn't already exist. Out-of-scope for v0.1.0
@@ -99,7 +110,7 @@ async fn full_write_read_delete_cycle() {
 async fn ensure_container(b: &AzureBlobBackend, name: &str) {
     let http = reqwest::Client::new();
     let mut url = b.endpoint().clone();
-    url.set_path(&format!("/{}", name));
+    url.set_path(&format!("/{name}"));
     url.set_query(Some("restype=container"));
 
     // Authorize the PUT manually using our signer.
@@ -116,7 +127,11 @@ async fn ensure_container(b: &AzureBlobBackend, name: &str) {
     let auth = sign(
         "devstoreaccount1",
         &SecretString::new(AZURITE_KEY.into()),
-        &SignRequest { method: "PUT", url: &url, headers: &headers },
+        &SignRequest {
+            method: "PUT",
+            url: &url,
+            headers: &headers,
+        },
     )
     .unwrap();
     let resp = http

--- a/crates/arkived-core/tests/azurite_crud.rs
+++ b/crates/arkived-core/tests/azurite_crud.rs
@@ -1,0 +1,137 @@
+//! Integration test against Azurite verifying our hand-rolled Blob REST
+//! client works end-to-end through SharedKey auth.
+//!
+//! **Gating:** `#[ignore]` by default. Requires Azurite on 127.0.0.1:10000.
+//!
+//! ```text
+//! docker run -d -p 10000:10000 mcr.microsoft.com/azure-storage/azurite \
+//!     azurite-blob --blobHost 0.0.0.0 --silent
+//! cargo test -p arkived-core --test azurite_crud -- --ignored
+//! ```
+
+use arkived_core::auth::{AuthProvider, AzuriteEmulatorProvider};
+use arkived_core::backend::AzureBlobBackend;
+use arkived_core::backend::{BlobEntry, BlobPath, DeleteOpts, WriteOpts};
+use arkived_core::policy::AllowAllPolicy;
+use arkived_core::progress::NoopSink;
+use arkived_core::Ctx;
+use bytes::Bytes;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use std::sync::Arc;
+
+const AZURITE_BLOB_ENDPOINT: &str = "http://127.0.0.1:10000/devstoreaccount1";
+
+async fn backend() -> AzureBlobBackend {
+    let provider = AzuriteEmulatorProvider::new();
+    let cred = provider.resolve().await.unwrap();
+    let url = url::Url::parse(AZURITE_BLOB_ENDPOINT).unwrap();
+    AzureBlobBackend::new(url, cred).unwrap()
+}
+
+fn ctx() -> Ctx {
+    let provider: Arc<dyn AuthProvider> = Arc::new(AzuriteEmulatorProvider::new());
+    Ctx::new(provider, Arc::new(AllowAllPolicy)).with_progress(Arc::new(NoopSink))
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_containers_against_azurite() {
+    let b = backend().await;
+    let page = b.list_containers(None).await.expect("azurite must be running");
+    // We don't assert count — Azurite starts empty in CI but might have state on a dev box.
+    println!("containers: {}", page.items.len());
+}
+
+#[tokio::test]
+#[ignore]
+async fn full_write_read_delete_cycle() {
+    let b = backend().await;
+    let c = ctx();
+
+    // Ensure a container exists. Azurite doesn't auto-create; we cheat by
+    // calling PUT container via reqwest directly for this test since
+    // create_container isn't in v0.1.0 scope.
+    ensure_container(&b, "arkivedci").await;
+
+    let path = BlobPath::new("arkivedci", format!("test-{}", uuid::Uuid::new_v4()));
+    let body_bytes = Bytes::from("hello-arkived");
+    let body = stream::iter(vec![Ok::<_, arkived_core::Error>(body_bytes.clone())]).boxed();
+
+    // WRITE
+    let wr = b
+        .write_blob(
+            &c,
+            &path,
+            body,
+            WriteOpts {
+                overwrite: true,
+                content_type: Some("text/plain".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("write_blob");
+    assert!(!wr.etag.is_empty());
+
+    // READ
+    let stream = b.read_blob(&path, None).await.expect("read_blob");
+    let collected: Bytes = stream
+        .try_fold(bytes::BytesMut::new(), |mut acc, chunk| async move {
+            acc.extend_from_slice(&chunk);
+            Ok(acc)
+        })
+        .await
+        .expect("stream")
+        .freeze();
+    assert_eq!(&collected[..], b"hello-arkived");
+
+    // LIST
+    let page = b.list_blobs("arkivedci", None, None, None).await.expect("list_blobs");
+    assert!(page.items.iter().any(|e| matches!(e, BlobEntry::Blob { name, .. } if name == &path.blob)));
+
+    // DELETE
+    b.delete_blob(&c, &path, DeleteOpts::default()).await.expect("delete_blob");
+}
+
+/// Create a container if it doesn't already exist. Out-of-scope for v0.1.0
+/// proper (container creation lands in the Backend-Depth plan), so we roll
+/// it here as a test helper only.
+async fn ensure_container(b: &AzureBlobBackend, name: &str) {
+    let http = reqwest::Client::new();
+    let mut url = b.endpoint().clone();
+    url.set_path(&format!("/{}", name));
+    url.set_query(Some("restype=container"));
+
+    // Authorize the PUT manually using our signer.
+    use arkived_core::auth::shared_key::{sign, SignRequest};
+    use secrecy::SecretString;
+
+    const AZURITE_KEY: &str =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    let date = httpdate::fmt_http_date(std::time::SystemTime::now());
+    let headers = vec![
+        ("x-ms-date".into(), date.clone()),
+        ("x-ms-version".into(), "2022-11-02".into()),
+    ];
+    let auth = sign(
+        "devstoreaccount1",
+        &SecretString::new(AZURITE_KEY.into()),
+        &SignRequest { method: "PUT", url: &url, headers: &headers },
+    )
+    .unwrap();
+    let resp = http
+        .put(url)
+        .header("x-ms-date", &date)
+        .header("x-ms-version", "2022-11-02")
+        .header("authorization", &auth)
+        .header("content-length", "0")
+        .send()
+        .await
+        .expect("azurite PUT container");
+    // 201 = created, 409 = ContainerAlreadyExists — both fine.
+    assert!(
+        resp.status().is_success() || resp.status().as_u16() == 409,
+        "PUT container status: {}",
+        resp.status()
+    );
+}

--- a/docs/superpowers/plans/2026-04-21-v0.1.0-backend.md
+++ b/docs/superpowers/plans/2026-04-21-v0.1.0-backend.md
@@ -1,0 +1,2621 @@
+# v0.1.0 Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a hand-rolled Azure Blob + ADLS Gen2 REST client in `arkived-core` that consumes the `ResolvedCredential` from the Auth plan and implements 5 core storage operations (list containers, list blobs, read, write, delete) with Policy-gated safety and Azurite-validated integration tests. End state: `arkived-core` can talk to real Azure Blob Storage end-to-end; the CLI and desktop app plans can build on top.
+
+**Architecture:** Hand-rolled `reqwest`-based HTTP client rather than `azure_storage_blob::BlobClient` (the current 0.11.x SDK exposes too few operations for ASE-parity). Auth dispatching: SharedKey pre-signs each request via the existing `shared_key` module; SAS decorates the URL; Entra sets a bearer header using `azure_identity::TokenCredential`; Anonymous sends no auth. XML responses are parsed with `quick-xml + serde`. The existing `pub(crate) StorageBackend` trait is kept as an internal seam; the public API is an `AzureBlobBackend` struct whose methods mirror Azure REST verbs.
+
+**Tech Stack:** Rust 1.88, reqwest 0.12 (rustls), quick-xml 0.36 with serde feature, bytes 1, futures 0.3, time 0.3, everything already in the Auth plan.
+
+---
+
+## Scope guardrails
+
+- **In scope:** HTTP pipeline + auth bridges + XML parsing + 5 operations (list_containers, list_blobs, read_blob, write_blob block blob, delete_blob) + Policy invariant + Azurite integration tests.
+- **Out of scope (next plans):** `set_access_tier`, `set_public_access`, `set_acl` (ADLS POSIX), `generate_sas` (client-side), lease ops, versions, snapshots, undelete, immutability, lifecycle. These are the "depth" operations and land in a focused Backend-Depth plan after this ships.
+- **Not touched:** CLI verbs (own plan), Tauri wire-up (own plan), Policy impls beyond `AllowAll`/`DenyAll` (own plan).
+
+---
+
+## File structure
+
+**Created in this plan:**
+
+- `crates/arkived-core/src/backend/azure/mod.rs` — `AzureBlobBackend` struct, `BlobBackendBuilder`, endpoint resolution
+- `crates/arkived-core/src/backend/azure/http.rs` — `HttpPipeline`: reqwest wrapper with auth + retry + tracing
+- `crates/arkived-core/src/backend/azure/auth_bridge.rs` — apply `ResolvedCredential` to a request
+- `crates/arkived-core/src/backend/azure/retry.rs` — retry policy (exponential backoff + jitter on transient)
+- `crates/arkived-core/src/backend/azure/error.rs` — Azure REST error XML → `crate::Error`
+- `crates/arkived-core/src/backend/azure/xml.rs` — XML deserialization helpers
+- `crates/arkived-core/src/backend/azure/models.rs` — request/response DTOs for the 5 ops
+- `crates/arkived-core/src/backend/azure/ops/list_containers.rs`
+- `crates/arkived-core/src/backend/azure/ops/list_blobs.rs`
+- `crates/arkived-core/src/backend/azure/ops/read_blob.rs`
+- `crates/arkived-core/src/backend/azure/ops/write_blob.rs`
+- `crates/arkived-core/src/backend/azure/ops/delete_blob.rs`
+- `crates/arkived-core/src/backend/azure/ops/mod.rs`
+- `crates/arkived-core/src/backend/types.rs` — `BlobPath`, `Container`, `BlobEntry`, `Page`, `Range`, `WriteOpts`, `WriteResult`, `DeleteOpts`, `ByteStream`
+- `crates/arkived-core/tests/azurite_crud.rs` — list/read/write/delete integration tests (gated, `#[ignore]`)
+
+**Modified in this plan:**
+
+- `crates/arkived-core/src/backend/mod.rs` — flesh out `StorageBackend` trait, re-export types, register submodules
+- `crates/arkived-core/src/lib.rs` — re-export public backend surface
+- `crates/arkived-core/Cargo.toml` — add quick-xml
+- `Cargo.toml` (root) — add quick-xml to workspace deps
+
+---
+
+## Task 1: Add backend workspace deps
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root)
+- Modify: `crates/arkived-core/Cargo.toml`
+
+- [ ] **Step 1: Append to `[workspace.dependencies]` in root `Cargo.toml`:**
+
+```toml
+quick-xml = { version = "0.36", features = ["serialize"] }
+```
+
+- [ ] **Step 2: Pull it into arkived-core** — append under `[dependencies]` in `crates/arkived-core/Cargo.toml`:
+
+```toml
+quick-xml = { workspace = true }
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo check -p arkived-core`
+Expected: downloads quick-xml; clean finish.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml crates/arkived-core/Cargo.toml
+git commit -m "deps(core): add quick-xml for Azure REST response parsing"
+```
+
+---
+
+## Task 2: `backend::types` — shared request/response types
+
+**Files:**
+- Create: `crates/arkived-core/src/backend/types.rs`
+- Modify: `crates/arkived-core/src/backend/mod.rs` (add `pub mod types;`)
+
+- [ ] **Step 1: Create `crates/arkived-core/src/backend/types.rs` with:**
+
+```rust
+//! Shared request/response types for the backend layer.
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use time::OffsetDateTime;
+
+/// A fully-qualified blob path: `(container, blob_name)`.
+///
+/// `blob_name` may contain `/` — the delimiter is just a name part, not a
+/// filesystem separator. ADLS Gen2 uses the same path as hierarchical name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobPath {
+    /// Container name (lowercase, letters/digits/hyphens, 3-63 chars).
+    pub container: String,
+    /// Blob name (slash-delimited for hierarchical paths).
+    pub blob: String,
+}
+
+impl BlobPath {
+    /// Construct from container + blob.
+    pub fn new(container: impl Into<String>, blob: impl Into<String>) -> Self {
+        Self { container: container.into(), blob: blob.into() }
+    }
+}
+
+/// A list page — items plus an optional continuation token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Page<T> {
+    /// Items on this page.
+    pub items: Vec<T>,
+    /// Continuation token for the next page, or `None` if this is the last.
+    pub continuation: Option<String>,
+}
+
+/// A container in the list-containers response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Container {
+    /// Container name.
+    pub name: String,
+    /// Last-modified timestamp.
+    pub last_modified: Option<OffsetDateTime>,
+    /// ETag.
+    pub etag: Option<String>,
+    /// Lease status (e.g. `"available"`, `"leased"`).
+    pub lease_status: Option<String>,
+    /// Lease state.
+    pub lease_state: Option<String>,
+    /// Public-access level (`"blob"`, `"container"`, or `None` for private).
+    pub public_access: Option<String>,
+}
+
+/// A blob or virtual directory entry in the list-blobs response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlobEntry {
+    /// A concrete blob.
+    Blob {
+        /// Full blob name.
+        name: String,
+        /// Size in bytes.
+        size: u64,
+        /// Blob type (`"BlockBlob"`, `"PageBlob"`, `"AppendBlob"`).
+        blob_type: String,
+        /// Access tier (`"Hot"`, `"Cool"`, `"Cold"`, `"Archive"`).
+        tier: Option<String>,
+        /// ETag.
+        etag: Option<String>,
+        /// Content-Type header from upload.
+        content_type: Option<String>,
+        /// Last-modified timestamp.
+        last_modified: Option<OffsetDateTime>,
+        /// Lease state.
+        lease_state: Option<String>,
+    },
+    /// A virtual directory prefix (emitted when `delimiter` is used).
+    Prefix {
+        /// The directory name (includes trailing delimiter).
+        name: String,
+    },
+}
+
+/// An HTTP byte range for `read_blob`.
+#[derive(Debug, Clone, Copy)]
+pub struct Range {
+    /// Start offset (inclusive).
+    pub start: u64,
+    /// End offset (inclusive). `None` = to end of blob.
+    pub end: Option<u64>,
+}
+
+/// Upload options.
+#[derive(Debug, Clone, Default)]
+pub struct WriteOpts {
+    /// If `false`, fail with `Conflict` when the blob already exists.
+    pub overwrite: bool,
+    /// Conditional: only overwrite if server ETag matches.
+    pub if_match: Option<String>,
+    /// Content-Type metadata to set on the blob.
+    pub content_type: Option<String>,
+    /// Arbitrary blob metadata headers.
+    pub metadata: HashMap<String, String>,
+    /// Max block size in bytes. Default 4 MiB.
+    pub block_size: Option<usize>,
+    /// Max parallel block uploads. Default 8.
+    pub max_parallelism: Option<usize>,
+}
+
+/// Result of a successful upload.
+#[derive(Debug, Clone)]
+pub struct WriteResult {
+    /// Server-assigned ETag.
+    pub etag: String,
+    /// Server-reported last-modified timestamp.
+    pub last_modified: Option<OffsetDateTime>,
+    /// Blob type (always `"BlockBlob"` for v0.1.0).
+    pub blob_type: String,
+}
+
+/// Delete options.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteOpts {
+    /// Delete snapshots too. Required if the blob has any (otherwise 409).
+    pub include_snapshots: bool,
+}
+
+/// Convenience alias for a byte-producing stream.
+pub type ByteStream = BoxStream<'static, crate::Result<Bytes>>;
+```
+
+- [ ] **Step 2: Register** — in `crates/arkived-core/src/backend/mod.rs`, after the existing doc block + `#[allow(dead_code)]` trait, add:
+
+```rust
+pub mod types;
+```
+
+Do not re-export yet; Task 3 wires up the public surface.
+
+- [ ] **Step 3: Build-check**
+
+Run: `cargo check -p arkived-core`
+Expected: clean. (No tests yet in this file; it's just type definitions.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/types.rs crates/arkived-core/src/backend/mod.rs
+git commit -m "feat(core): add backend shared types (BlobPath, Container, BlobEntry, Page, WriteOpts, ...)"
+```
+
+---
+
+## Task 3: `StorageBackend` trait fleshed out + `AzureBlobBackend` skeleton
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/mod.rs`
+- Create: `crates/arkived-core/src/backend/azure/mod.rs`
+
+- [ ] **Step 1: Flesh out `StorageBackend` trait.** Replace the contents of `crates/arkived-core/src/backend/mod.rs` with:
+
+```rust
+//! Storage backend trait and implementations.
+//!
+//! The [`StorageBackend`] trait is intentionally `pub(crate)` — an internal
+//! seam that will enable future backends (S3, GCS, etc.) to be added without
+//! restructuring the core. It is **not** part of the public API.
+//!
+//! Public consumers use [`azure::AzureBlobBackend`] directly; its method
+//! names and shapes are Azure-native.
+
+pub mod azure;
+pub mod types;
+
+pub use azure::AzureBlobBackend;
+pub use types::{
+    BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range, WriteOpts, WriteResult,
+};
+
+use crate::Ctx;
+use async_trait::async_trait;
+
+/// The internal storage backend abstraction.
+///
+/// **Stability: internal.** This trait is `pub(crate)` and may change without
+/// notice. Do not implement or depend on it outside this crate.
+#[async_trait]
+pub(crate) trait StorageBackend: Send + Sync {
+    /// Human-readable name (e.g. `"azure-blob"`).
+    fn name(&self) -> &'static str;
+
+    /// List containers under the storage account.
+    async fn list_containers(
+        &self,
+        ctx: &Ctx,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>>;
+
+    /// List blobs under a container with optional prefix and delimiter.
+    ///
+    /// When `delimiter` is `Some("/")`, virtual directories emerge as
+    /// [`BlobEntry::Prefix`] entries.
+    async fn list_blobs(
+        &self,
+        ctx: &Ctx,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>>;
+
+    /// Stream the bytes of a blob.
+    async fn read_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream>;
+
+    /// Upload a blob. Calls `ctx.policy.confirm` before overwriting an
+    /// existing blob.
+    async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult>;
+
+    /// Delete a blob. Always policy-gated.
+    async fn delete_blob(&self, ctx: &Ctx, path: &BlobPath, opts: DeleteOpts) -> crate::Result<()>;
+}
+```
+
+- [ ] **Step 2: Create `crates/arkived-core/src/backend/azure/mod.rs` skeleton:**
+
+```rust
+//! Azure Blob Storage + ADLS Gen2 backend, hand-rolled on `reqwest`.
+//!
+//! The backend consumes a [`ResolvedCredential`] from the auth layer and
+//! dispatches requests via [`http::HttpPipeline`] which applies the
+//! appropriate auth bridge (SharedKey HMAC signing, SAS URL decoration,
+//! Entra bearer token, or anonymous).
+//!
+//! See [`crate::backend`](crate::backend) for shared types.
+
+pub(crate) mod auth_bridge;
+pub(crate) mod error;
+pub(crate) mod http;
+pub(crate) mod models;
+pub(crate) mod ops;
+pub(crate) mod retry;
+pub(crate) mod xml;
+
+use crate::auth::ResolvedCredential;
+use std::sync::Arc;
+
+/// Azure Blob / ADLS Gen2 backend.
+///
+/// Construct via [`AzureBlobBackend::new`]. Methods map 1:1 to Azure REST
+/// verbs (`list_containers`, `list_blobs`, `read_blob`, `write_blob`,
+/// `delete_blob`).
+#[derive(Clone)]
+pub struct AzureBlobBackend {
+    /// Account blob endpoint URL (no trailing slash), e.g.
+    /// `https://acme.blob.core.windows.net`.
+    endpoint: url::Url,
+    /// Credential to attach to every outgoing request.
+    credential: Arc<ResolvedCredential>,
+    /// Shared reqwest client for connection reuse.
+    http: reqwest::Client,
+}
+
+impl std::fmt::Debug for AzureBlobBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzureBlobBackend")
+            .field("endpoint", &self.endpoint.as_str())
+            .field("credential", &self.credential.kind())
+            .finish()
+    }
+}
+
+impl AzureBlobBackend {
+    /// Construct a backend from an endpoint URL and resolved credential.
+    pub fn new(endpoint: url::Url, credential: ResolvedCredential) -> crate::Result<Self> {
+        Ok(Self {
+            endpoint,
+            credential: Arc::new(credential),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    /// The configured blob endpoint URL.
+    pub fn endpoint(&self) -> &url::Url {
+        &self.endpoint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ResolvedCredential;
+
+    #[test]
+    fn construction_succeeds() {
+        let url = url::Url::parse("https://acme.blob.core.windows.net").unwrap();
+        let b = AzureBlobBackend::new(url.clone(), ResolvedCredential::Anonymous).unwrap();
+        assert_eq!(b.endpoint(), &url);
+    }
+
+    #[test]
+    fn debug_hides_credential_contents() {
+        let url = url::Url::parse("https://acme.blob.core.windows.net").unwrap();
+        let b = AzureBlobBackend::new(url, ResolvedCredential::Anonymous).unwrap();
+        let dbg = format!("{b:?}");
+        assert!(dbg.contains("AzureBlobBackend"));
+        assert!(dbg.contains("acme.blob.core.windows.net"));
+    }
+}
+```
+
+- [ ] **Step 3: Create stub files for the child modules** so the declarations resolve. Each file starts as a minimal placeholder that later tasks replace:
+
+`crates/arkived-core/src/backend/azure/auth_bridge.rs`:
+
+```rust
+//! Apply a `ResolvedCredential` to outgoing requests. Filled in Task 5.
+```
+
+`crates/arkived-core/src/backend/azure/error.rs`:
+
+```rust
+//! Azure REST error → `crate::Error` mapping. Filled in Task 7.
+```
+
+`crates/arkived-core/src/backend/azure/http.rs`:
+
+```rust
+//! reqwest-backed request pipeline. Filled in Task 6.
+```
+
+`crates/arkived-core/src/backend/azure/models.rs`:
+
+```rust
+//! XML DTOs for Azure REST requests/responses. Filled in Task 9.
+```
+
+`crates/arkived-core/src/backend/azure/retry.rs`:
+
+```rust
+//! Exponential backoff with jitter. Filled in Task 8.
+```
+
+`crates/arkived-core/src/backend/azure/xml.rs`:
+
+```rust
+//! Shared XML deserialization helpers. Filled in Task 9.
+```
+
+`crates/arkived-core/src/backend/azure/ops/mod.rs`:
+
+```rust
+//! Per-REST-verb implementations. Individual submodules land in Tasks 10–14.
+```
+
+- [ ] **Step 4: Run the crate-level tests**
+
+Run: `cargo test -p arkived-core --lib backend::`
+Expected: 2 new tests pass (`construction_succeeds`, `debug_hides_credential_contents`) in addition to whatever else exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/
+git commit -m "feat(core): StorageBackend trait + AzureBlobBackend skeleton"
+```
+
+---
+
+## Task 4: Error XML model + `rest_error_from_response`
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/error.rs`
+
+- [ ] **Step 1: Replace `crates/arkived-core/src/backend/azure/error.rs` with:**
+
+```rust
+//! Azure REST error → `crate::Error` mapping.
+//!
+//! Azure returns errors as an XML body `<Error><Code>...</Code><Message>...</Message></Error>`
+//! with a status code. We map well-known codes (`BlobNotFound`,
+//! `ContainerNotFound`, `ConditionNotMet`, `ServerBusy`, …) to specific
+//! `crate::Error` variants; everything else becomes `Error::Backend(msg)`.
+
+use crate::Error;
+use quick_xml::de::from_str;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Parsed Azure error body.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AzureError {
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "Message")]
+    pub message: String,
+}
+
+/// Map a non-success HTTP response to a `crate::Error`.
+///
+/// Takes the response status and body text and dispatches to the right
+/// variant. Also reads the `x-ms-retry-after` header for `Throttled`.
+pub(crate) fn map_rest_error(
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+    body: &str,
+) -> Error {
+    // Parse body as Azure error; if that fails, fall through to Backend with the raw text.
+    let parsed: Option<AzureError> = from_str(body).ok();
+    let code = parsed.as_ref().map(|e| e.code.as_str()).unwrap_or("Unknown");
+    let message = parsed
+        .as_ref()
+        .map(|e| e.message.as_str())
+        .unwrap_or(body);
+
+    match (status.as_u16(), code) {
+        (404, _) => Error::NotFound {
+            resource: format!("{code}: {message}"),
+        },
+        (403, _) => Error::AuthFailed(format!("{code}: {message}")),
+        (401, _) => Error::AuthExpired,
+        (409, "BlobAlreadyExists") | (412, _) => Error::Conflict {
+            detail: format!("{code}: {message}"),
+            etag: headers
+                .get("etag")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string()),
+        },
+        (503 | 429, _) => {
+            let retry_after = headers
+                .get("x-ms-retry-after")
+                .or_else(|| headers.get("retry-after"))
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or(Duration::from_secs(3));
+            Error::Throttled { retry_after }
+        }
+        (500..=599, _) => Error::Backend(format!("server error {status}: {code}: {message}")),
+        _ => Error::Backend(format!("HTTP {status}: {code}: {message}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::{header::HeaderMap, StatusCode};
+
+    fn hdr(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    const BLOB_NOT_FOUND: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<Error><Code>BlobNotFound</Code><Message>The specified blob does not exist.</Message></Error>"#;
+
+    #[test]
+    fn map_404_to_not_found() {
+        let err = map_rest_error(StatusCode::NOT_FOUND, &hdr(&[]), BLOB_NOT_FOUND);
+        assert!(matches!(err, Error::NotFound { .. }));
+    }
+
+    #[test]
+    fn map_401_to_auth_expired() {
+        let err = map_rest_error(StatusCode::UNAUTHORIZED, &hdr(&[]), "");
+        assert!(matches!(err, Error::AuthExpired));
+    }
+
+    #[test]
+    fn map_403_to_auth_failed() {
+        let err = map_rest_error(StatusCode::FORBIDDEN, &hdr(&[]), BLOB_NOT_FOUND);
+        assert!(matches!(err, Error::AuthFailed(_)));
+    }
+
+    #[test]
+    fn map_503_to_throttled_with_retry_after() {
+        let err = map_rest_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &hdr(&[("x-ms-retry-after", "7")]),
+            "",
+        );
+        match err {
+            Error::Throttled { retry_after } => assert_eq!(retry_after, Duration::from_secs(7)),
+            other => panic!("expected Throttled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_412_to_conflict_with_etag() {
+        let err = map_rest_error(
+            StatusCode::PRECONDITION_FAILED,
+            &hdr(&[("etag", "0x8DCABCDEF")]),
+            r#"<Error><Code>ConditionNotMet</Code><Message>.</Message></Error>"#,
+        );
+        match err {
+            Error::Conflict { etag, .. } => assert_eq!(etag.as_deref(), Some("0x8DCABCDEF")),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_body_becomes_backend_error() {
+        let err = map_rest_error(StatusCode::IM_A_TEAPOT, &hdr(&[]), "not xml!");
+        assert!(matches!(err, Error::Backend(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::error::`
+Expected: 6 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/error.rs
+git commit -m "feat(core): Azure REST error XML → crate::Error mapping"
+```
+
+---
+
+## Task 5: Auth bridge — apply `ResolvedCredential` to `reqwest::RequestBuilder`
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/auth_bridge.rs`
+
+- [ ] **Step 1: Replace `crates/arkived-core/src/backend/azure/auth_bridge.rs` with:**
+
+```rust
+//! Apply a [`ResolvedCredential`] to an outgoing `reqwest::Request`.
+//!
+//! - **Entra**: add `Authorization: Bearer <token>`. Token acquired via
+//!   the `TokenCredential` with scope `https://storage.azure.com/.default`.
+//! - **SharedKey**: sign with HMAC-SHA256 via [`crate::auth::shared_key::sign`]
+//!   and set `Authorization: SharedKey <account>:<sig>`. This needs to happen
+//!   *after* headers are finalized, so this module exposes a post-build hook.
+//! - **SAS**: merge the SAS query string into the URL. If both have a `sig=`
+//!   the SAS wins.
+//! - **Anonymous**: no-op.
+
+use crate::auth::shared_key::{sign, SignRequest};
+use crate::auth::ResolvedCredential;
+use crate::Error;
+use azure_core::credentials::TokenCredential;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
+use reqwest::{Request, Url};
+use std::sync::Arc;
+
+/// `x-ms-version` header value — pinned to a stable REST API version.
+pub(crate) const MS_VERSION: &str = "2022-11-02";
+
+/// Decorate the URL for SAS credentials (append the SAS query). Called
+/// *before* the request is built so subsequent signing sees the final URL.
+pub(crate) fn decorate_url(cred: &ResolvedCredential, url: &mut Url) {
+    if let ResolvedCredential::Sas(sas) = cred {
+        use secrecy::ExposeSecret;
+        let sas_str = sas.expose_secret();
+        // Merge SAS query params into the URL, preserving any that already exist.
+        // We just append; duplicates would be odd but not wrong per SAS spec.
+        let existing = url.query().map(String::from);
+        let merged = match existing {
+            Some(q) if !q.is_empty() => format!("{q}&{sas_str}"),
+            _ => sas_str.to_string(),
+        };
+        url.set_query(Some(&merged));
+    }
+}
+
+/// Apply auth to a built request. This is the single choke point.
+///
+/// Sets `x-ms-date` and `x-ms-version` for all methods. For SharedKey,
+/// signs after all headers are set. For Entra, acquires a token and
+/// sets the Bearer header.
+pub(crate) async fn apply_auth(
+    cred: &ResolvedCredential,
+    request: &mut Request,
+) -> crate::Result<()> {
+    // Always set the date + API version headers.
+    let date = httpdate::fmt_http_date(std::time::SystemTime::now());
+    request.headers_mut().insert(
+        HeaderName::from_static("x-ms-date"),
+        HeaderValue::from_str(&date).map_err(|e| Error::Backend(format!("x-ms-date: {e}")))?,
+    );
+    request.headers_mut().insert(
+        HeaderName::from_static("x-ms-version"),
+        HeaderValue::from_static(MS_VERSION),
+    );
+
+    match cred {
+        ResolvedCredential::Anonymous | ResolvedCredential::Sas(_) => Ok(()),
+        ResolvedCredential::Entra(tc) => apply_entra(tc.clone(), request).await,
+        ResolvedCredential::SharedKey { account_name, key } => {
+            apply_shared_key(account_name, key, request)
+        }
+    }
+}
+
+async fn apply_entra(
+    tc: Arc<dyn TokenCredential>,
+    request: &mut Request,
+) -> crate::Result<()> {
+    let token = tc
+        .get_token(&["https://storage.azure.com/.default"], None)
+        .await
+        .map_err(|e| Error::AuthFailed(format!("get_token: {e}")))?;
+    let header = format!("Bearer {}", token.token.secret());
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&header).map_err(|e| Error::AuthFailed(format!("bearer header: {e}")))?,
+    );
+    Ok(())
+}
+
+fn apply_shared_key(
+    account_name: &str,
+    key: &secrecy::SecretString,
+    request: &mut Request,
+) -> crate::Result<()> {
+    let method = request.method().as_str().to_string();
+    let url = request.url().clone();
+
+    let header_pairs: Vec<(String, String)> = request
+        .headers()
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_str().to_string(),
+                v.to_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+
+    let signed = sign(
+        account_name,
+        key,
+        &SignRequest {
+            method: &method,
+            url: &url,
+            headers: &header_pairs,
+        },
+    )
+    .map_err(|e| Error::AuthFailed(format!("SharedKey sign: {e:?}")))?;
+
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&signed).map_err(|e| Error::AuthFailed(format!("auth header: {e}")))?,
+    );
+    Ok(())
+}
+
+/// Copy a reqwest `HeaderMap` into the `Vec<(String, String)>` shape the
+/// signer consumes. Exposed for testing.
+#[cfg(test)]
+pub(crate) fn headers_as_pairs(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn build_get(url: &str) -> Request {
+        reqwest::Client::new().get(url).build().unwrap()
+    }
+
+    #[tokio::test]
+    async fn anonymous_sets_date_and_version_only() {
+        let mut req = build_get("https://example.com/container");
+        apply_auth(&ResolvedCredential::Anonymous, &mut req).await.unwrap();
+        assert!(req.headers().contains_key("x-ms-date"));
+        assert_eq!(
+            req.headers().get("x-ms-version").unwrap(),
+            MS_VERSION
+        );
+        assert!(!req.headers().contains_key(AUTHORIZATION));
+    }
+
+    #[tokio::test]
+    async fn shared_key_sets_signed_authorization() {
+        let mut req = build_get("https://acme.blob.core.windows.net/?comp=list");
+        apply_auth(
+            &ResolvedCredential::SharedKey {
+                account_name: "acme".into(),
+                key: SecretString::new(
+                    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==".into(),
+                ),
+            },
+            &mut req,
+        )
+        .await
+        .unwrap();
+        let auth = req.headers().get(AUTHORIZATION).unwrap().to_str().unwrap();
+        assert!(auth.starts_with("SharedKey acme:"));
+    }
+
+    #[test]
+    fn sas_is_merged_into_url_query() {
+        let mut url = Url::parse("https://acme.blob.core.windows.net/c/b").unwrap();
+        let cred = ResolvedCredential::Sas(SecretString::new("sv=2022&sig=XYZ".into()));
+        decorate_url(&cred, &mut url);
+        assert_eq!(url.query(), Some("sv=2022&sig=XYZ"));
+
+        let mut url2 = Url::parse("https://acme.blob.core.windows.net/c?existing=1").unwrap();
+        decorate_url(&cred, &mut url2);
+        assert_eq!(url2.query(), Some("existing=1&sv=2022&sig=XYZ"));
+    }
+
+    #[test]
+    fn sas_decoration_is_noop_for_non_sas() {
+        let mut url = Url::parse("https://acme.blob.core.windows.net/c/b").unwrap();
+        decorate_url(&ResolvedCredential::Anonymous, &mut url);
+        assert_eq!(url.query(), None);
+    }
+
+    #[test]
+    fn headers_as_pairs_roundtrips() {
+        let mut h = HeaderMap::new();
+        h.insert("x-ms-date", "Mon".parse().unwrap());
+        h.insert("x-ms-version", "2022-11-02".parse().unwrap());
+        let pairs = headers_as_pairs(&h);
+        assert_eq!(pairs.len(), 2);
+        assert!(pairs.iter().any(|(k, v)| k == "x-ms-date" && v == "Mon"));
+    }
+}
+```
+
+- [ ] **Step 2: Ensure `httpdate` is a regular dep** (it was a dev-dep in the Auth plan). In `crates/arkived-core/Cargo.toml`, under `[dependencies]`, append `httpdate = { workspace = true }`. If that's already there (because the test moved it up), skip. The dev-dep entry can stay.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::auth_bridge::`
+Expected: 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/auth_bridge.rs crates/arkived-core/Cargo.toml
+git commit -m "feat(core): auth bridge — apply ResolvedCredential to reqwest requests"
+```
+
+---
+
+## Task 6: `HttpPipeline` — signed, retried request dispatch
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/http.rs`
+
+- [ ] **Step 1: Replace `crates/arkived-core/src/backend/azure/http.rs` with:**
+
+```rust
+//! The reqwest-backed request pipeline.
+//!
+//! Every request to Azure flows through [`HttpPipeline::send`]:
+//! 1. Clone the URL and apply SAS decoration.
+//! 2. Build the request with caller-supplied method/headers/body.
+//! 3. Apply auth (sets `x-ms-date`, `x-ms-version`, `Authorization`).
+//! 4. Send; on success, hand back the response.
+//! 5. On transient error (throttle / 5xx / network), retry with backoff
+//!    via [`super::retry::with_retries`].
+//! 6. On terminal error, convert to `crate::Error` via [`super::error::map_rest_error`].
+
+use crate::auth::ResolvedCredential;
+use crate::backend::azure::auth_bridge::{apply_auth, decorate_url};
+use crate::backend::azure::error::map_rest_error;
+use crate::backend::azure::retry::with_retries;
+use crate::Error;
+use bytes::Bytes;
+use reqwest::{Method, Response};
+
+/// Per-request body: unit for no-body, Bytes for inline, stream handled by caller.
+#[derive(Debug, Clone)]
+pub(crate) enum Body {
+    /// No request body.
+    Empty,
+    /// Inline bytes body (content-length is set automatically).
+    Bytes(Bytes),
+}
+
+/// A single request template. Cloned across retries.
+#[derive(Debug, Clone)]
+pub(crate) struct RequestTemplate {
+    pub method: Method,
+    pub url: url::Url,
+    /// Name-value header pairs to set on the request (in addition to auth).
+    pub headers: Vec<(String, String)>,
+    pub body: Body,
+}
+
+/// Outbound pipeline.
+pub(crate) struct HttpPipeline<'a> {
+    pub http: &'a reqwest::Client,
+    pub credential: &'a ResolvedCredential,
+}
+
+impl<'a> HttpPipeline<'a> {
+    /// Send a request with auth + retry, returning the raw response on 2xx.
+    pub async fn send(&self, tmpl: RequestTemplate) -> crate::Result<Response> {
+        with_retries(|| async { self.send_once(tmpl.clone()).await }).await
+    }
+
+    async fn send_once(&self, mut tmpl: RequestTemplate) -> crate::Result<Response> {
+        decorate_url(self.credential, &mut tmpl.url);
+
+        let mut builder = self
+            .http
+            .request(tmpl.method.clone(), tmpl.url.clone());
+        for (k, v) in &tmpl.headers {
+            builder = builder.header(k, v);
+        }
+        builder = match tmpl.body {
+            Body::Empty => builder.header("content-length", "0"),
+            Body::Bytes(b) => builder.body(b),
+        };
+
+        let mut request = builder
+            .build()
+            .map_err(|e| Error::Backend(format!("build request: {e}")))?;
+
+        apply_auth(self.credential, &mut request).await?;
+
+        let resp = self
+            .http
+            .execute(request)
+            .await
+            .map_err(|e| Error::NetworkTransient(format!("execute: {e}")))?;
+
+        if resp.status().is_success() {
+            return Ok(resp);
+        }
+
+        // Pull headers + body for error mapping.
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = resp.text().await.unwrap_or_default();
+        Err(map_rest_error(status, &headers, &body))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ResolvedCredential;
+
+    #[tokio::test]
+    async fn sends_anonymous_get_returns_response_on_2xx() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/hello")
+            .with_status(200)
+            .with_body("ok")
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let cred = ResolvedCredential::Anonymous;
+        let pipeline = HttpPipeline { http: &http, credential: &cred };
+
+        let url = url::Url::parse(&format!("{}/hello", server.url())).unwrap();
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn maps_404_to_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock("GET", "/missing")
+            .with_status(404)
+            .with_body(
+                r#"<?xml version="1.0"?><Error><Code>BlobNotFound</Code><Message>gone</Message></Error>"#,
+            )
+            .create_async()
+            .await;
+
+        let http = reqwest::Client::new();
+        let cred = ResolvedCredential::Anonymous;
+        let pipeline = HttpPipeline { http: &http, credential: &cred };
+        let url = url::Url::parse(&format!("{}/missing", server.url())).unwrap();
+        let err = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::NotFound { .. }));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::http::`
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/http.rs
+git commit -m "feat(core): HttpPipeline — signed + retried Azure request dispatch"
+```
+
+---
+
+## Task 7: Retry policy
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/retry.rs`
+
+- [ ] **Step 1: Replace `crates/arkived-core/src/backend/azure/retry.rs` with:**
+
+```rust
+//! Retry policy for transient errors.
+//!
+//! Retries are triggered by `Error::Throttled`, `Error::NetworkTransient`,
+//! and `Error::Backend(...)` where the message indicates a 5xx (we treat
+//! all Backend errors as retryable for simplicity — 5xx responses already
+//! map there via `map_rest_error`).
+//!
+//! Schedule: exponential backoff with full jitter, capped at 30s, max
+//! 8 attempts. `Throttled { retry_after }` respects the server's
+//! suggested delay as a lower bound.
+
+use crate::Error;
+use std::time::Duration;
+
+/// Max retry attempts (including the first).
+pub(crate) const MAX_ATTEMPTS: usize = 8;
+
+/// Maximum backoff cap.
+pub(crate) const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Run `f` with exponential-backoff retries on transient errors.
+pub(crate) async fn with_retries<F, Fut, T>(mut f: F) -> crate::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = crate::Result<T>>,
+{
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) if !is_retryable(&e) || attempt >= MAX_ATTEMPTS => return Err(e),
+            Err(e) => {
+                let delay = backoff_for(attempt, &e);
+                tracing::debug!(attempt, ?delay, ?e, "retryable error; backing off");
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+fn is_retryable(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::Throttled { .. } | Error::NetworkTransient(_) | Error::Backend(_)
+    )
+}
+
+fn backoff_for(attempt: usize, e: &Error) -> Duration {
+    // Respect server-directed retry-after if present.
+    if let Error::Throttled { retry_after } = e {
+        return (*retry_after).min(MAX_BACKOFF);
+    }
+
+    // Exponential with full jitter. base = 100ms * 2^(attempt-1), capped.
+    let base_ms: u64 = 100u64.saturating_mul(1u64 << (attempt.saturating_sub(1).min(10)));
+    let capped = base_ms.min(MAX_BACKOFF.as_millis() as u64);
+    // Full jitter: uniform in [0, capped].
+    let jittered = fastrand_u64(capped);
+    Duration::from_millis(jittered)
+}
+
+fn fastrand_u64(max_exclusive: u64) -> u64 {
+    if max_exclusive == 0 {
+        return 0;
+    }
+    // Tiny LCG keyed off nanosecond clock — good enough for retry jitter.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64 | ((d.as_secs() as u64) << 32))
+        .unwrap_or(0);
+    (nanos.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407)) % max_exclusive
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn retries_on_transient_then_succeeds() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a2 = attempts.clone();
+        let out: crate::Result<i32> = with_retries(|| {
+            let a = a2.clone();
+            async move {
+                let n = a.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(Error::NetworkTransient("flaky".into()))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(out.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_error_fails_fast() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a2 = attempts.clone();
+        let out: crate::Result<i32> = with_retries(|| {
+            let a = a2.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                Err(Error::NotFound { resource: "x".into() })
+            }
+        })
+        .await;
+        assert!(matches!(out, Err(Error::NotFound { .. })));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_attempts() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let a2 = attempts.clone();
+        let out: crate::Result<i32> = with_retries(|| {
+            let a = a2.clone();
+            async move {
+                a.fetch_add(1, Ordering::SeqCst);
+                Err(Error::NetworkTransient("always".into()))
+            }
+        })
+        .await;
+        assert!(matches!(out, Err(Error::NetworkTransient(_))));
+        assert_eq!(attempts.load(Ordering::SeqCst), MAX_ATTEMPTS);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::retry::`
+Expected: 3 tests pass. The "gives up after MAX_ATTEMPTS" test can take a few seconds because backoff is real-time — that's fine.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/retry.rs
+git commit -m "feat(core): retry policy — exponential backoff with jitter on transients"
+```
+
+---
+
+## Task 8: XML helpers + shared response types
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/xml.rs`
+- Modify: `crates/arkived-core/src/backend/azure/models.rs`
+
+- [ ] **Step 1: Replace `crates/arkived-core/src/backend/azure/xml.rs` with:**
+
+```rust
+//! Shared XML deserialization helpers for Azure REST responses.
+
+use crate::Error;
+use quick_xml::de::from_str;
+use serde::de::DeserializeOwned;
+
+/// Parse a response body as XML.
+pub(crate) fn parse_xml<T: DeserializeOwned>(body: &str) -> crate::Result<T> {
+    from_str(body).map_err(|e| Error::Backend(format!("parse xml: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Greeting {
+        #[serde(rename = "$text")]
+        text: String,
+    }
+
+    #[test]
+    fn round_trips_simple_xml() {
+        let doc = r#"<Greeting>hello</Greeting>"#;
+        let g: Greeting = parse_xml(doc).unwrap();
+        assert_eq!(g.text, "hello");
+    }
+
+    #[test]
+    fn malformed_becomes_backend_error() {
+        let err: crate::Result<Greeting> = parse_xml("<not xml>");
+        assert!(matches!(err, Err(Error::Backend(_))));
+    }
+}
+```
+
+- [ ] **Step 2: Replace `crates/arkived-core/src/backend/azure/models.rs` with:**
+
+```rust
+//! XML DTOs for Azure Blob REST responses.
+//!
+//! These are the wire-level types; they're converted to the public
+//! [`Container`](crate::backend::Container) / [`BlobEntry`](crate::backend::BlobEntry)
+//! types in each op module.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ListContainersResult {
+    #[serde(rename = "Containers", default)]
+    pub containers: ContainerList,
+    #[serde(rename = "NextMarker", default)]
+    pub next_marker: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ContainerList {
+    #[serde(rename = "Container", default)]
+    pub items: Vec<XmlContainer>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct XmlContainer {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Properties", default)]
+    pub properties: ContainerProperties,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct ContainerProperties {
+    #[serde(rename = "Last-Modified", default)]
+    pub last_modified: Option<String>,
+    #[serde(rename = "Etag", default)]
+    pub etag: Option<String>,
+    #[serde(rename = "LeaseStatus", default)]
+    pub lease_status: Option<String>,
+    #[serde(rename = "LeaseState", default)]
+    pub lease_state: Option<String>,
+    #[serde(rename = "PublicAccess", default)]
+    pub public_access: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ListBlobsResult {
+    #[serde(rename = "Prefix", default)]
+    pub prefix: Option<String>,
+    #[serde(rename = "Blobs", default)]
+    pub blobs: BlobList,
+    #[serde(rename = "NextMarker", default)]
+    pub next_marker: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct BlobList {
+    #[serde(rename = "Blob", default)]
+    pub items: Vec<XmlBlob>,
+    #[serde(rename = "BlobPrefix", default)]
+    pub prefixes: Vec<XmlBlobPrefix>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct XmlBlob {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Properties", default)]
+    pub properties: BlobProperties,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct BlobProperties {
+    #[serde(rename = "Last-Modified", default)]
+    pub last_modified: Option<String>,
+    #[serde(rename = "Etag", default)]
+    pub etag: Option<String>,
+    #[serde(rename = "Content-Length", default)]
+    pub content_length: Option<u64>,
+    #[serde(rename = "Content-Type", default)]
+    pub content_type: Option<String>,
+    #[serde(rename = "BlobType", default)]
+    pub blob_type: Option<String>,
+    #[serde(rename = "AccessTier", default)]
+    pub access_tier: Option<String>,
+    #[serde(rename = "LeaseState", default)]
+    pub lease_state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct XmlBlobPrefix {
+    #[serde(rename = "Name")]
+    pub name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::azure::xml::parse_xml;
+
+    const LIST_CONTAINERS: &str = r#"<?xml version="1.0"?>
+<EnumerationResults>
+  <Containers>
+    <Container>
+      <Name>alpha</Name>
+      <Properties>
+        <Last-Modified>Mon, 21 Apr 2026 12:00:00 GMT</Last-Modified>
+        <Etag>0x8DC</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>beta</Name>
+      <Properties>
+        <PublicAccess>blob</PublicAccess>
+      </Properties>
+    </Container>
+  </Containers>
+  <NextMarker/>
+</EnumerationResults>"#;
+
+    #[test]
+    fn parse_list_containers() {
+        let r: ListContainersResult = parse_xml(LIST_CONTAINERS).unwrap();
+        assert_eq!(r.containers.items.len(), 2);
+        assert_eq!(r.containers.items[0].name, "alpha");
+        assert_eq!(
+            r.containers.items[0].properties.lease_state.as_deref(),
+            Some("available")
+        );
+        assert_eq!(
+            r.containers.items[1].properties.public_access.as_deref(),
+            Some("blob")
+        );
+    }
+
+    const LIST_BLOBS: &str = r#"<?xml version="1.0"?>
+<EnumerationResults ContainerName="device-twins">
+  <Prefix>sync/</Prefix>
+  <Blobs>
+    <Blob>
+      <Name>sync/part-00001.parquet</Name>
+      <Properties>
+        <Last-Modified>Mon, 21 Apr 2026 11:11:42 GMT</Last-Modified>
+        <Etag>0x8DC7A9F</Etag>
+        <Content-Length>14221000</Content-Length>
+        <Content-Type>application/octet-stream</Content-Type>
+        <BlobType>BlockBlob</BlobType>
+        <AccessTier>Hot</AccessTier>
+        <LeaseState>available</LeaseState>
+      </Properties>
+    </Blob>
+    <BlobPrefix><Name>sync/2026-04/</Name></BlobPrefix>
+  </Blobs>
+  <NextMarker>AAAA</NextMarker>
+</EnumerationResults>"#;
+
+    #[test]
+    fn parse_list_blobs() {
+        let r: ListBlobsResult = parse_xml(LIST_BLOBS).unwrap();
+        assert_eq!(r.blobs.items.len(), 1);
+        assert_eq!(r.blobs.prefixes.len(), 1);
+        assert_eq!(r.blobs.items[0].properties.content_length, Some(14221000));
+        assert_eq!(r.blobs.prefixes[0].name, "sync/2026-04/");
+        assert_eq!(r.next_marker.as_deref(), Some("AAAA"));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::xml:: backend::azure::models::`
+Expected: 4 tests pass (2 in xml::tests, 2 in models::tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/xml.rs crates/arkived-core/src/backend/azure/models.rs
+git commit -m "feat(core): XML parsing helpers + list_containers/list_blobs DTOs"
+```
+
+---
+
+## Task 9: `list_containers` operation
+
+**Files:**
+- Create: `crates/arkived-core/src/backend/azure/ops/list_containers.rs`
+- Modify: `crates/arkived-core/src/backend/azure/ops/mod.rs`
+- Modify: `crates/arkived-core/src/backend/azure/mod.rs` (add `list_containers` method)
+
+- [ ] **Step 1: Create `crates/arkived-core/src/backend/azure/ops/list_containers.rs`:**
+
+```rust
+//! `GET /?comp=list` — list containers.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::models::ListContainersResult;
+use crate::backend::azure::xml::parse_xml;
+use crate::backend::types::{Container, Page};
+use crate::backend::azure::AzureBlobBackend;
+use reqwest::Method;
+use time::format_description::well_known::Rfc2822;
+use time::OffsetDateTime;
+
+impl AzureBlobBackend {
+    /// GET /?comp=list — return a page of containers.
+    pub async fn list_containers(
+        &self,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>> {
+        let mut url = self.endpoint.clone();
+        // Service-level list: path is "/", query comp=list.
+        url.set_path("/");
+        let mut query = String::from("comp=list");
+        if let Some(marker) = &continuation {
+            query.push_str(&format!("&marker={}", urlencoding::encode(marker)));
+        }
+        url.set_query(Some(&query));
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await?;
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| crate::Error::Backend(format!("read list_containers body: {e}")))?;
+        let parsed: ListContainersResult = parse_xml(&body)?;
+
+        let items: Vec<Container> = parsed
+            .containers
+            .items
+            .into_iter()
+            .map(|x| Container {
+                name: x.name,
+                last_modified: x
+                    .properties
+                    .last_modified
+                    .as_deref()
+                    .and_then(|s| OffsetDateTime::parse(s, &Rfc2822).ok()),
+                etag: x.properties.etag,
+                lease_status: x.properties.lease_status,
+                lease_state: x.properties.lease_state,
+                public_access: x.properties.public_access,
+            })
+            .collect();
+
+        Ok(Page {
+            items,
+            continuation: parsed.next_marker.filter(|s| !s.is_empty()),
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Register the op submodule.** In `crates/arkived-core/src/backend/azure/ops/mod.rs`, replace the placeholder content with:
+
+```rust
+//! Per-REST-verb implementations.
+
+pub(crate) mod list_containers;
+```
+
+- [ ] **Step 3: Add `urlencoding` workspace dep.** In root `Cargo.toml` under `[workspace.dependencies]`, append:
+
+```toml
+urlencoding = "2"
+```
+
+In `crates/arkived-core/Cargo.toml` under `[dependencies]`, append:
+
+```toml
+urlencoding = { workspace = true }
+```
+
+- [ ] **Step 4: Build + test**
+
+Run: `cargo test -p arkived-core --lib backend::azure::ops::list_containers::`
+Expected: clean compile. No unit tests for this op (it exercises live HTTP); covered by the Azurite integration test in Task 16. The build is the smoke test here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/ops/list_containers.rs crates/arkived-core/src/backend/azure/ops/mod.rs Cargo.toml crates/arkived-core/Cargo.toml
+git commit -m "feat(core): list_containers operation (Azure Blob REST)"
+```
+
+---
+
+## Task 10: `list_blobs` operation
+
+**Files:**
+- Create: `crates/arkived-core/src/backend/azure/ops/list_blobs.rs`
+- Modify: `crates/arkived-core/src/backend/azure/ops/mod.rs`
+
+- [ ] **Step 1: Create `crates/arkived-core/src/backend/azure/ops/list_blobs.rs`:**
+
+```rust
+//! `GET /{container}?restype=container&comp=list` — list blobs in a container.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::models::ListBlobsResult;
+use crate::backend::azure::xml::parse_xml;
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobEntry, Page};
+use reqwest::Method;
+use time::format_description::well_known::Rfc2822;
+use time::OffsetDateTime;
+
+impl AzureBlobBackend {
+    /// GET /{container}?restype=container&comp=list — return a page of blobs.
+    ///
+    /// - `prefix`: only list blobs whose name starts with this string.
+    /// - `delimiter`: if `Some("/")`, returns virtual directory prefixes as
+    ///   [`BlobEntry::Prefix`] entries instead of full blob names.
+    /// - `continuation`: opaque marker from a prior call's
+    ///   [`Page::continuation`].
+    pub async fn list_blobs(
+        &self,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>> {
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}", container));
+        let mut query = String::from("restype=container&comp=list");
+        if let Some(p) = prefix {
+            query.push_str(&format!("&prefix={}", urlencoding::encode(p)));
+        }
+        if let Some(d) = delimiter {
+            query.push_str(&format!("&delimiter={}", urlencoding::encode(d)));
+        }
+        if let Some(m) = &continuation {
+            query.push_str(&format!("&marker={}", urlencoding::encode(m)));
+        }
+        url.set_query(Some(&query));
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers: vec![],
+                body: Body::Empty,
+            })
+            .await?;
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| crate::Error::Backend(format!("read list_blobs body: {e}")))?;
+        let parsed: ListBlobsResult = parse_xml(&body)?;
+
+        let mut items: Vec<BlobEntry> = Vec::new();
+
+        for b in parsed.blobs.items {
+            items.push(BlobEntry::Blob {
+                name: b.name,
+                size: b.properties.content_length.unwrap_or(0),
+                blob_type: b
+                    .properties
+                    .blob_type
+                    .unwrap_or_else(|| "BlockBlob".into()),
+                tier: b.properties.access_tier,
+                etag: b.properties.etag,
+                content_type: b.properties.content_type,
+                last_modified: b
+                    .properties
+                    .last_modified
+                    .as_deref()
+                    .and_then(|s| OffsetDateTime::parse(s, &Rfc2822).ok()),
+                lease_state: b.properties.lease_state,
+            });
+        }
+        for pfx in parsed.blobs.prefixes {
+            items.push(BlobEntry::Prefix { name: pfx.name });
+        }
+
+        Ok(Page {
+            items,
+            continuation: parsed.next_marker.filter(|s| !s.is_empty()),
+        })
+    }
+}
+```
+
+- [ ] **Step 2: Register** — in `ops/mod.rs`, append `pub(crate) mod list_blobs;`.
+
+- [ ] **Step 3: Build**
+
+Run: `cargo check -p arkived-core`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/ops/list_blobs.rs crates/arkived-core/src/backend/azure/ops/mod.rs
+git commit -m "feat(core): list_blobs operation with prefix + delimiter + continuation"
+```
+
+---
+
+## Task 11: `read_blob` operation — streaming
+
+**Files:**
+- Create: `crates/arkived-core/src/backend/azure/ops/read_blob.rs`
+- Modify: `crates/arkived-core/src/backend/azure/ops/mod.rs`
+
+- [ ] **Step 1: Create `crates/arkived-core/src/backend/azure/ops/read_blob.rs`:**
+
+```rust
+//! `GET /{container}/{blob}` — read a blob as a byte stream.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobPath, ByteStream, Range};
+use crate::Error;
+use futures::stream::{StreamExt, TryStreamExt};
+use reqwest::Method;
+
+impl AzureBlobBackend {
+    /// Stream a blob's bytes. Supports HTTP ranged reads via `range`.
+    pub async fn read_blob(
+        &self,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream> {
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}/{}", path.container, path.blob));
+        url.set_query(None);
+
+        let mut headers = Vec::<(String, String)>::new();
+        if let Some(r) = range {
+            let range_header = match r.end {
+                Some(end) => format!("bytes={}-{}", r.start, end),
+                None => format!("bytes={}-", r.start),
+            };
+            headers.push(("x-ms-range".into(), range_header));
+        }
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::GET,
+                url,
+                headers,
+                body: Body::Empty,
+            })
+            .await?;
+
+        let stream = resp
+            .bytes_stream()
+            .map_err(|e| Error::NetworkTransient(format!("read_blob stream: {e}")))
+            .boxed();
+        Ok(stream)
+    }
+}
+```
+
+- [ ] **Step 2: Register** — in `ops/mod.rs`, append `pub(crate) mod read_blob;`.
+
+- [ ] **Step 3: Build**
+
+Run: `cargo check -p arkived-core`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/ops/read_blob.rs crates/arkived-core/src/backend/azure/ops/mod.rs
+git commit -m "feat(core): read_blob — streaming GET with optional range"
+```
+
+---
+
+## Task 12: `write_blob` — single-shot block-blob upload
+
+**Files:**
+- Create: `crates/arkived-core/src/backend/azure/ops/write_blob.rs`
+- Modify: `crates/arkived-core/src/backend/azure/ops/mod.rs`
+
+Scope note: v0.1.0 ships single-shot block-blob uploads only (PUT Blob). Chunked multi-block uploads (Put Block + Put Block List) are a follow-up in the Backend-Depth plan.
+
+- [ ] **Step 1: Create `crates/arkived-core/src/backend/azure/ops/write_blob.rs`:**
+
+```rust
+//! `PUT /{container}/{blob}` — single-shot block-blob upload.
+//!
+//! Azure allows block blobs up to 5000 MiB via a single `PUT Blob` request.
+//! For now we buffer the stream into memory before uploading. Chunked
+//! (Put Block + Put Block List) flows are a Backend-Depth plan follow-up.
+//!
+//! **Policy gating:** calls `ctx.policy.confirm(...)` when the blob would be
+//! overwritten.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobPath, ByteStream, WriteOpts, WriteResult};
+use crate::policy::{Action, ActionContext, PolicyDecision};
+use crate::{Ctx, Error};
+use bytes::{Bytes, BytesMut};
+use futures::stream::StreamExt;
+use reqwest::Method;
+use time::format_description::well_known::Rfc2822;
+use time::OffsetDateTime;
+
+impl AzureBlobBackend {
+    /// Upload a block blob in one request.
+    ///
+    /// If `opts.overwrite` is false and the blob exists, returns
+    /// [`Error::Conflict`]. If overwrite is true AND the blob exists, this
+    /// method first calls `ctx.policy.confirm("overwrite_blob", ...)`.
+    pub async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult> {
+        // Buffer the stream. For v0.1.0 we cap bodies at 256 MiB in memory;
+        // larger uploads get the chunked flow in the depth plan.
+        const MAX_INLINE_BYTES: usize = 256 * 1024 * 1024;
+        let bytes = collect_bytes(body, MAX_INLINE_BYTES).await?;
+
+        // Policy gate on potential overwrite.
+        if opts.overwrite {
+            let decision = ctx
+                .policy
+                .confirm(
+                    &Action {
+                        verb: "overwrite_blob".into(),
+                        target: format!("{}/{}", path.container, path.blob),
+                        summary: format!(
+                            "overwrite {}/{} with {} bytes",
+                            path.container,
+                            path.blob,
+                            bytes.len()
+                        ),
+                        reversible: false,
+                    },
+                    &ActionContext {
+                        item_count: Some(1),
+                        ..Default::default()
+                    },
+                )
+                .await;
+            match decision {
+                PolicyDecision::Allow | PolicyDecision::AllowAlways { .. } => {}
+                PolicyDecision::Deny(reason) => return Err(Error::PolicyDenied(reason)),
+            }
+        }
+
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}/{}", path.container, path.blob));
+        url.set_query(None);
+
+        let mut headers: Vec<(String, String)> = vec![
+            ("x-ms-blob-type".into(), "BlockBlob".into()),
+            ("content-length".into(), bytes.len().to_string()),
+        ];
+        if let Some(ct) = &opts.content_type {
+            headers.push(("content-type".into(), ct.clone()));
+        } else {
+            headers.push(("content-type".into(), "application/octet-stream".into()));
+        }
+        if !opts.overwrite {
+            headers.push(("if-none-match".into(), "*".into()));
+        }
+        if let Some(etag) = &opts.if_match {
+            headers.push(("if-match".into(), etag.clone()));
+        }
+        for (k, v) in &opts.metadata {
+            headers.push((format!("x-ms-meta-{k}"), v.clone()));
+        }
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let resp = pipeline
+            .send(RequestTemplate {
+                method: Method::PUT,
+                url,
+                headers,
+                body: Body::Bytes(bytes),
+            })
+            .await?;
+
+        let etag = resp
+            .headers()
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let last_modified = resp
+            .headers()
+            .get("last-modified")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| OffsetDateTime::parse(s, &Rfc2822).ok());
+
+        Ok(WriteResult {
+            etag,
+            last_modified,
+            blob_type: "BlockBlob".into(),
+        })
+    }
+}
+
+async fn collect_bytes(mut stream: ByteStream, max: usize) -> crate::Result<Bytes> {
+    let mut buf = BytesMut::new();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk?;
+        if buf.len() + bytes.len() > max {
+            return Err(Error::Backend(format!(
+                "upload body exceeds {max} bytes (chunked upload lands in Backend-Depth plan)"
+            )));
+        }
+        buf.extend_from_slice(&bytes);
+    }
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn collect_bytes_returns_full_body() {
+        let chunks: Vec<crate::Result<Bytes>> =
+            vec![Ok(Bytes::from("hello ")), Ok(Bytes::from("world"))];
+        let s = stream::iter(chunks).boxed();
+        let body = collect_bytes(s, 1024).await.unwrap();
+        assert_eq!(&body[..], b"hello world");
+    }
+
+    #[tokio::test]
+    async fn collect_bytes_errors_above_limit() {
+        let chunks: Vec<crate::Result<Bytes>> =
+            vec![Ok(Bytes::from(vec![0u8; 600])), Ok(Bytes::from(vec![0u8; 600]))];
+        let s = stream::iter(chunks).boxed();
+        let err = collect_bytes(s, 1000).await.unwrap_err();
+        assert!(matches!(err, Error::Backend(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Register** — in `ops/mod.rs`, append `pub(crate) mod write_blob;`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::ops::write_blob::`
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/ops/write_blob.rs crates/arkived-core/src/backend/azure/ops/mod.rs
+git commit -m "feat(core): write_blob — single-shot block blob upload with Policy gate"
+```
+
+---
+
+## Task 13: `delete_blob` — policy-gated DELETE
+
+**Files:**
+- Create: `crates/arkived-core/src/backend/azure/ops/delete_blob.rs`
+- Modify: `crates/arkived-core/src/backend/azure/ops/mod.rs`
+
+- [ ] **Step 1: Create `crates/arkived-core/src/backend/azure/ops/delete_blob.rs`:**
+
+```rust
+//! `DELETE /{container}/{blob}` — policy-gated blob deletion.
+
+use crate::backend::azure::http::{Body, HttpPipeline, RequestTemplate};
+use crate::backend::azure::AzureBlobBackend;
+use crate::backend::types::{BlobPath, DeleteOpts};
+use crate::policy::{Action, ActionContext, PolicyDecision};
+use crate::{Ctx, Error};
+use reqwest::Method;
+
+impl AzureBlobBackend {
+    /// Delete a blob. Calls `ctx.policy.confirm("delete_blob", ...)` before
+    /// any HTTP is sent. Denies the operation on `Deny`.
+    pub async fn delete_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        opts: DeleteOpts,
+    ) -> crate::Result<()> {
+        let decision = ctx
+            .policy
+            .confirm(
+                &Action {
+                    verb: "delete_blob".into(),
+                    target: format!("{}/{}", path.container, path.blob),
+                    summary: format!("delete {}/{}", path.container, path.blob),
+                    reversible: true,
+                },
+                &ActionContext {
+                    item_count: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await;
+        match decision {
+            PolicyDecision::Allow | PolicyDecision::AllowAlways { .. } => {}
+            PolicyDecision::Deny(reason) => return Err(Error::PolicyDenied(reason)),
+        }
+
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("/{}/{}", path.container, path.blob));
+        url.set_query(None);
+
+        let mut headers = Vec::<(String, String)>::new();
+        if opts.include_snapshots {
+            headers.push(("x-ms-delete-snapshots".into(), "include".into()));
+        }
+
+        let pipeline = HttpPipeline {
+            http: &self.http,
+            credential: &self.credential,
+        };
+        let _ = pipeline
+            .send(RequestTemplate {
+                method: Method::DELETE,
+                url,
+                headers,
+                body: Body::Empty,
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::ResolvedCredential;
+    use crate::backend::azure::AzureBlobBackend;
+    use crate::policy::DenyAllPolicy;
+    use crate::progress::NoopSink;
+    use crate::types::{AuthKind, ResourceKind};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct FakeAuth;
+    #[async_trait]
+    impl crate::auth::AuthProvider for FakeAuth {
+        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
+        fn display_name(&self) -> &str { "fake" }
+        async fn resolve(&self) -> crate::Result<ResolvedCredential> {
+            Ok(ResolvedCredential::Anonymous)
+        }
+        fn supports(&self, _: ResourceKind) -> bool { true }
+    }
+
+    #[tokio::test]
+    async fn deny_all_policy_short_circuits_before_http() {
+        let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
+        let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
+        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
+            .with_progress(Arc::new(NoopSink));
+
+        let err = backend
+            .delete_blob(&ctx, &BlobPath::new("c", "b"), DeleteOpts::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PolicyDenied(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Register** — in `ops/mod.rs`, append `pub(crate) mod delete_blob;`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::ops::delete_blob::`
+Expected: 1 test passes — proves the Policy-gate short-circuits before we ever attempt HTTP.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/ops/delete_blob.rs crates/arkived-core/src/backend/azure/ops/mod.rs
+git commit -m "feat(core): delete_blob — DELETE with mandatory Policy confirmation"
+```
+
+---
+
+## Task 14: Implement the internal `StorageBackend` trait for `AzureBlobBackend`
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/mod.rs`
+
+- [ ] **Step 1: Append the trait impl at the end of `crates/arkived-core/src/backend/azure/mod.rs`:**
+
+```rust
+use crate::backend::types::{BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range, WriteOpts, WriteResult};
+use crate::backend::StorageBackend;
+use crate::Ctx;
+use async_trait::async_trait;
+
+#[async_trait]
+impl StorageBackend for AzureBlobBackend {
+    fn name(&self) -> &'static str { "azure-blob" }
+
+    async fn list_containers(
+        &self,
+        _ctx: &Ctx,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<Container>> {
+        AzureBlobBackend::list_containers(self, continuation).await
+    }
+
+    async fn list_blobs(
+        &self,
+        _ctx: &Ctx,
+        container: &str,
+        prefix: Option<&str>,
+        delimiter: Option<&str>,
+        continuation: Option<String>,
+    ) -> crate::Result<Page<BlobEntry>> {
+        AzureBlobBackend::list_blobs(self, container, prefix, delimiter, continuation).await
+    }
+
+    async fn read_blob(
+        &self,
+        _ctx: &Ctx,
+        path: &BlobPath,
+        range: Option<Range>,
+    ) -> crate::Result<ByteStream> {
+        AzureBlobBackend::read_blob(self, path, range).await
+    }
+
+    async fn write_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        body: ByteStream,
+        opts: WriteOpts,
+    ) -> crate::Result<WriteResult> {
+        AzureBlobBackend::write_blob(self, ctx, path, body, opts).await
+    }
+
+    async fn delete_blob(
+        &self,
+        ctx: &Ctx,
+        path: &BlobPath,
+        opts: DeleteOpts,
+    ) -> crate::Result<()> {
+        AzureBlobBackend::delete_blob(self, ctx, path, opts).await
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo check -p arkived-core`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/mod.rs
+git commit -m "feat(core): AzureBlobBackend implements internal StorageBackend trait"
+```
+
+---
+
+## Task 15: Re-export public backend surface + update `lib.rs`
+
+**Files:**
+- Modify: `crates/arkived-core/src/lib.rs`
+
+- [ ] **Step 1: Update re-exports**
+
+In `crates/arkived-core/src/lib.rs`, change the line:
+
+```rust
+pub(crate) mod backend;
+```
+
+to:
+
+```rust
+pub mod backend;
+```
+
+(The trait inside stays `pub(crate)`; the module itself and `AzureBlobBackend` + supporting types become public.)
+
+Then add a re-export of the public backend entry points at the crate root:
+
+```rust
+pub use backend::{
+    AzureBlobBackend, BlobEntry, BlobPath, ByteStream, Container, DeleteOpts, Page, Range,
+    WriteOpts, WriteResult,
+};
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cargo test -p arkived-core --lib`
+Expected: all tests still pass; public API compiles.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/lib.rs
+git commit -m "feat(core): expose backend module + AzureBlobBackend at crate root"
+```
+
+---
+
+## Task 16: Azurite integration test — list + read
+
+**Files:**
+- Create: `crates/arkived-core/tests/azurite_crud.rs`
+
+- [ ] **Step 1: Create `crates/arkived-core/tests/azurite_crud.rs`:**
+
+```rust
+//! Integration test against Azurite verifying our hand-rolled Blob REST
+//! client works end-to-end through SharedKey auth.
+//!
+//! **Gating:** `#[ignore]` by default. Requires Azurite on 127.0.0.1:10000.
+//!
+//! ```text
+//! docker run -d -p 10000:10000 mcr.microsoft.com/azure-storage/azurite \
+//!     azurite-blob --blobHost 0.0.0.0 --silent
+//! cargo test -p arkived-core --test azurite_crud -- --ignored
+//! ```
+
+use arkived_core::auth::{AzuriteEmulatorProvider, AuthProvider};
+use arkived_core::backend::AzureBlobBackend;
+use arkived_core::backend::{BlobEntry, BlobPath, DeleteOpts, WriteOpts};
+use arkived_core::policy::AllowAllPolicy;
+use arkived_core::progress::NoopSink;
+use arkived_core::Ctx;
+use bytes::Bytes;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use std::sync::Arc;
+
+const AZURITE_BLOB_ENDPOINT: &str = "http://127.0.0.1:10000/devstoreaccount1";
+
+async fn backend() -> AzureBlobBackend {
+    let provider = AzuriteEmulatorProvider::new();
+    let cred = provider.resolve().await.unwrap();
+    let url = url::Url::parse(AZURITE_BLOB_ENDPOINT).unwrap();
+    AzureBlobBackend::new(url, cred).unwrap()
+}
+
+fn ctx() -> Ctx {
+    let provider: Arc<dyn AuthProvider> = Arc::new(AzuriteEmulatorProvider::new());
+    Ctx::new(provider, Arc::new(AllowAllPolicy)).with_progress(Arc::new(NoopSink))
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_containers_against_azurite() {
+    let b = backend().await;
+    let page = b.list_containers(None).await.expect("azurite must be running");
+    // We don't assert count — Azurite starts empty in CI but might have state on a dev box.
+    println!("containers: {}", page.items.len());
+}
+
+#[tokio::test]
+#[ignore]
+async fn full_write_read_delete_cycle() {
+    let b = backend().await;
+    let c = ctx();
+
+    // Ensure a container exists. Azurite doesn't auto-create; we cheat by
+    // calling PUT container via reqwest directly for this test since
+    // create_container isn't in v0.1.0 scope.
+    ensure_container(&b, "arkivedci").await;
+
+    let path = BlobPath::new("arkivedci", format!("test-{}", uuid::Uuid::new_v4()));
+    let body_bytes = Bytes::from("hello-arkived");
+    let body = stream::iter(vec![Ok::<_, arkived_core::Error>(body_bytes.clone())]).boxed();
+
+    // WRITE
+    let wr = b
+        .write_blob(
+            &c,
+            &path,
+            body,
+            WriteOpts {
+                overwrite: true,
+                content_type: Some("text/plain".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("write_blob");
+    assert!(!wr.etag.is_empty());
+
+    // READ
+    let stream = b.read_blob(&path, None).await.expect("read_blob");
+    let collected: Bytes = stream
+        .try_fold(bytes::BytesMut::new(), |mut acc, chunk| async move {
+            acc.extend_from_slice(&chunk);
+            Ok(acc)
+        })
+        .await
+        .expect("stream")
+        .freeze();
+    assert_eq!(&collected[..], b"hello-arkived");
+
+    // LIST
+    let page = b.list_blobs("arkivedci", None, None, None).await.expect("list_blobs");
+    assert!(page.items.iter().any(|e| matches!(e, BlobEntry::Blob { name, .. } if name == &path.blob)));
+
+    // DELETE
+    b.delete_blob(&c, &path, DeleteOpts::default()).await.expect("delete_blob");
+}
+
+/// Create a container if it doesn't already exist. Out-of-scope for v0.1.0
+/// proper (container creation lands in the Backend-Depth plan), so we roll
+/// it here as a test helper only.
+async fn ensure_container(b: &AzureBlobBackend, name: &str) {
+    let http = reqwest::Client::new();
+    let mut url = b.endpoint().clone();
+    url.set_path(&format!("/{}", name));
+    url.set_query(Some("restype=container"));
+
+    // Authorize the PUT manually using our signer.
+    use arkived_core::auth::shared_key::{sign, SignRequest};
+    use secrecy::SecretString;
+
+    const AZURITE_KEY: &str =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    let date = httpdate::fmt_http_date(std::time::SystemTime::now());
+    let headers = vec![
+        ("x-ms-date".into(), date.clone()),
+        ("x-ms-version".into(), "2022-11-02".into()),
+    ];
+    let auth = sign(
+        "devstoreaccount1",
+        &SecretString::new(AZURITE_KEY.into()),
+        &SignRequest { method: "PUT", url: &url, headers: &headers },
+    )
+    .unwrap();
+    let resp = http
+        .put(url)
+        .header("x-ms-date", &date)
+        .header("x-ms-version", "2022-11-02")
+        .header("authorization", &auth)
+        .header("content-length", "0")
+        .send()
+        .await
+        .expect("azurite PUT container");
+    // 201 = created, 409 = ContainerAlreadyExists — both fine.
+    assert!(
+        resp.status().is_success() || resp.status().as_u16() == 409,
+        "PUT container status: {}",
+        resp.status()
+    );
+}
+```
+
+- [ ] **Step 2: Compile-check without running**
+
+Run: `cargo test -p arkived-core --test azurite_crud --no-run`
+Expected: compiles clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/tests/azurite_crud.rs
+git commit -m "test(core): Azurite integration test — full CRUD cycle (gated, ignored)"
+```
+
+---
+
+## Task 17: Tracing spans on every request
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/http.rs`
+
+- [ ] **Step 1: Wrap the `send` method with a tracing span.**
+
+In `crates/arkived-core/src/backend/azure/http.rs`, modify the `HttpPipeline::send` method body to open a tracing span before calling `with_retries`:
+
+Replace:
+
+```rust
+    pub async fn send(&self, tmpl: RequestTemplate) -> crate::Result<Response> {
+        with_retries(|| async { self.send_once(tmpl.clone()).await }).await
+    }
+```
+
+with:
+
+```rust
+    pub async fn send(&self, tmpl: RequestTemplate) -> crate::Result<Response> {
+        let request_id = uuid::Uuid::new_v4();
+        let span = tracing::info_span!(
+            "azure_request",
+            request_id = %request_id,
+            method = %tmpl.method,
+            host = %tmpl.url.host_str().unwrap_or("?"),
+            path = %tmpl.url.path(),
+            auth = ?self.credential.kind(),
+        );
+        let _enter = span.enter();
+        let started = std::time::Instant::now();
+        let result = with_retries(|| async { self.send_once(tmpl.clone()).await }).await;
+        match &result {
+            Ok(resp) => {
+                tracing::info!(
+                    status = %resp.status(),
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    "azure_request ok"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    error = %e,
+                    "azure_request failed"
+                );
+            }
+        }
+        result
+    }
+```
+
+- [ ] **Step 2: Run the http tests to ensure they still pass**
+
+Run: `cargo test -p arkived-core --lib backend::azure::http::`
+Expected: 2 tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/http.rs
+git commit -m "feat(core): tracing spans on every Azure request (request_id + elapsed_ms)"
+```
+
+---
+
+## Task 18: Unit test — Policy invariant on write_blob overwrite
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/ops/write_blob.rs`
+
+- [ ] **Step 1: Append the following test to the existing `#[cfg(test)] mod tests` block in `crates/arkived-core/src/backend/azure/ops/write_blob.rs`:**
+
+```rust
+    use crate::auth::ResolvedCredential;
+    use crate::backend::AzureBlobBackend;
+    use crate::policy::DenyAllPolicy;
+    use crate::progress::NoopSink;
+    use crate::types::{AuthKind, ResourceKind};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct FakeAuth;
+    #[async_trait]
+    impl crate::auth::AuthProvider for FakeAuth {
+        fn kind(&self) -> AuthKind { AuthKind::Anonymous }
+        fn display_name(&self) -> &str { "fake" }
+        async fn resolve(&self) -> crate::Result<ResolvedCredential> {
+            Ok(ResolvedCredential::Anonymous)
+        }
+        fn supports(&self, _: ResourceKind) -> bool { true }
+    }
+
+    #[tokio::test]
+    async fn overwrite_with_deny_all_policy_blocks_before_http() {
+        let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
+        let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
+        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
+            .with_progress(Arc::new(NoopSink));
+
+        let chunks: Vec<crate::Result<Bytes>> = vec![Ok(Bytes::from("data"))];
+        let stream = futures::stream::iter(chunks).boxed();
+
+        let err = backend
+            .write_blob(
+                &ctx,
+                &BlobPath::new("c", "b"),
+                stream,
+                WriteOpts {
+                    overwrite: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PolicyDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn non_overwrite_write_does_not_invoke_policy() {
+        // With overwrite=false we never call policy.confirm, so DenyAllPolicy
+        // is irrelevant. This test only verifies the code path compiles and
+        // runs up to the HTTP call (which will fail on the unreachable URL,
+        // but that's a NetworkTransient rather than a PolicyDenied).
+        let endpoint = url::Url::parse("http://127.0.0.1:1/").unwrap();
+        let backend = AzureBlobBackend::new(endpoint, ResolvedCredential::Anonymous).unwrap();
+        let ctx = Ctx::new(Arc::new(FakeAuth), Arc::new(DenyAllPolicy))
+            .with_progress(Arc::new(NoopSink));
+
+        let chunks: Vec<crate::Result<Bytes>> = vec![Ok(Bytes::from("data"))];
+        let stream = futures::stream::iter(chunks).boxed();
+
+        let err = backend
+            .write_blob(
+                &ctx,
+                &BlobPath::new("c", "b"),
+                stream,
+                WriteOpts { overwrite: false, ..Default::default() },
+            )
+            .await
+            .unwrap_err();
+        // Should NOT be PolicyDenied — we skipped the policy check.
+        assert!(!matches!(err, Error::PolicyDenied(_)));
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::ops::write_blob::`
+Expected: 4 tests pass (2 existing + 2 new).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/ops/write_blob.rs
+git commit -m "test(core): Policy invariant tests for write_blob overwrite path"
+```
+
+---
+
+## Task 19: Write the `arkived account endpoint` URL helper
+
+**Files:**
+- Modify: `crates/arkived-core/src/backend/azure/mod.rs`
+
+- [ ] **Step 1: Add a convenience constructor that takes a storage account name + environment.**
+
+In `crates/arkived-core/src/backend/azure/mod.rs`, append inside `impl AzureBlobBackend` (after the existing `new` / `endpoint`):
+
+```rust
+    /// Construct from a storage account name + Azure environment.
+    ///
+    /// Builds the endpoint URL as `https://<account>.blob.<env_suffix>`.
+    pub fn for_account(
+        account_name: &str,
+        environment: &crate::types::AzureEnvironment,
+        credential: ResolvedCredential,
+    ) -> crate::Result<Self> {
+        let endpoint = url::Url::parse(&format!(
+            "https://{}.blob.{}",
+            account_name,
+            environment.storage_suffix()
+        ))
+        .map_err(|e| crate::Error::Backend(format!("build endpoint: {e}")))?;
+        Self::new(endpoint, credential)
+    }
+```
+
+And append this test inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn for_account_builds_public_endpoint() {
+        use crate::types::AzureEnvironment;
+        let b = AzureBlobBackend::for_account(
+            "acmeprod",
+            &AzureEnvironment::Public,
+            ResolvedCredential::Anonymous,
+        )
+        .unwrap();
+        assert_eq!(
+            b.endpoint().as_str(),
+            "https://acmeprod.blob.core.windows.net/"
+        );
+    }
+
+    #[test]
+    fn for_account_builds_china_endpoint() {
+        use crate::types::AzureEnvironment;
+        let b = AzureBlobBackend::for_account(
+            "acmeprod",
+            &AzureEnvironment::China,
+            ResolvedCredential::Anonymous,
+        )
+        .unwrap();
+        assert_eq!(
+            b.endpoint().as_str(),
+            "https://acmeprod.blob.core.chinacloudapi.cn/"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p arkived-core --lib backend::azure::tests::`
+Expected: 4 tests pass (2 existing + 2 new).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/arkived-core/src/backend/azure/mod.rs
+git commit -m "feat(core): AzureBlobBackend::for_account — account-name + environment constructor"
+```
+
+---
+
+## Task 20: Final fmt / clippy / tests / build
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --all --check`. If it fails, run `cargo fmt --all` and re-check.
+
+- [ ] **Step 2: Clippy**
+
+Run: `cargo clippy -p arkived-core --all-targets -- -D warnings`. If it fails, fix inline (likely `useless_conversion` cleanups similar to the Auth plan).
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cargo test -p arkived-core`. Expected: all previous unit + integration tests still pass, plus the new ~25 backend tests. Azurite CRUD test stays `#[ignore]`.
+
+- [ ] **Step 4: Workspace build**
+
+Run: `cargo build --workspace`. Expected: clean.
+
+- [ ] **Step 5: Doc build**
+
+Run: `cargo doc -p arkived-core --no-deps`. Expected: no missing_docs violations.
+
+- [ ] **Step 6: Commit any fmt/clippy fixes**
+
+If Steps 1 or 2 required changes, commit them:
+
+```bash
+git add -u
+git commit -m "style(core): cargo fmt + clippy after backend plan"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] All 5 operations present: `list_containers`, `list_blobs`, `read_blob`, `write_blob`, `delete_blob`.
+- [ ] `write_blob` (overwrite=true) and `delete_blob` both call `ctx.policy.confirm` before any HTTP — verified by unit tests in Tasks 13 + 18.
+- [ ] All three non-anonymous auth kinds signed: SharedKey (Task 5), Entra bearer (Task 5), SAS URL decoration (Task 5).
+- [ ] Retry policy handles `Throttled`, `NetworkTransient`, `Backend` errors with exponential backoff + jitter and honors `retry_after` (Task 7).
+- [ ] REST errors mapped to `Error::NotFound / Conflict / Throttled / AuthExpired / AuthFailed / Backend` (Task 4).
+- [ ] Every request goes through a tracing span with `request_id`, `method`, `host`, `path`, `auth` kind (Task 17).
+- [ ] Azurite integration test exercises write → read → list → delete (Task 16).
+- [ ] Public API at `arkived_core::backend::AzureBlobBackend` (re-exported at crate root) — no leaked internals.
+- [ ] `StorageBackend` trait still `pub(crate)` — confirmed by Task 3 + Task 14.
+
+---
+
+## What this plan does NOT cover (next plan — Backend-Depth)
+
+- `set_access_tier` + tier-change policy gate
+- `set_public_access` on containers (policy-gated)
+- `set_acl` for ADLS Gen2 (POSIX + RBAC ACL operations)
+- `generate_sas` (service SAS, user-delegation SAS)
+- Lease operations (acquire, renew, change, release, break)
+- Versions listing + read-by-version + delete-version
+- Snapshot create / list / delete / promote
+- Soft-delete `undelete_blob` + `purge_soft_deleted`
+- Immutability policies (legal hold, time-based retention)
+- Lifecycle rule get/set/delete
+- Chunked multi-block upload for blobs > 256 MiB (Put Block + Put Block List)
+- Container creation / deletion (beyond the test helper used in Task 16)
+
+All of these become their own focused plan after this ships.


### PR DESCRIPTION
## Summary

Hand-rolled Azure Blob REST client in `arkived-core`, since `azure_storage_blob 0.11` only exposes `upload/download/exists` — far too thin for ASE parity. This PR ships 5 core operations wired end-to-end with the Auth layer's `ResolvedCredential`:

- `list_containers` (Service list, continuation marker)
- `list_blobs` (prefix + delimiter + continuation pagination)
- `read_blob` (streaming GET with optional byte range)
- `write_blob` (single-shot BlockBlob PUT, Policy-gated on overwrite)
- `delete_blob` (DELETE, always Policy-gated)

## Infrastructure

- `HttpPipeline`: reqwest wrapper with auth + retry + tracing span per request
- `auth_bridge`: dispatches `ResolvedCredential` → request (SharedKey HMAC signing, Entra bearer token, SAS URL decoration, anonymous)
- Retry policy: exponential backoff + full jitter on `Throttled`/`NetworkTransient`/`Backend` errors, honors server `retry_after`, 8 attempts max, 30s cap
- Error mapping: Azure REST XML `<Error><Code>...</Code></Error>` → `crate::Error::{NotFound, Conflict, Throttled, AuthExpired, AuthFailed, Backend}`
- XML parsing via `quick-xml` + serde
- Tracing span on every request with `request_id` (UUID v4), `method`, `host`, `path`, `auth` kind, `elapsed_ms`

## Policy invariant

`write_blob` (overwrite=true) and `delete_blob` both call `ctx.policy.confirm(...)` before any HTTP is attempted. Unit tests with `DenyAllPolicy` prove short-circuit: `Error::PolicyDenied` returns without network contact.

## Public API

`AzureBlobBackend` at the crate root with two constructors:
- `AzureBlobBackend::new(endpoint, credential)` — explicit URL
- `AzureBlobBackend::for_account(name, env, credential)` — convenience, builds `https://<name>.blob.<env_suffix>`

Internal `StorageBackend` trait stays `pub(crate)` — implementation seam for future backends.

## Deferred (Backend-Depth plan)

- `set_access_tier`, `set_public_access`
- `set_acl` for ADLS Gen2 (POSIX + RBAC)
- `generate_sas` (service SAS + user-delegation SAS)
- Lease operations
- Versions, snapshots, undelete, immutability, lifecycle rules
- Chunked multi-block upload for blobs > 256 MiB
- Container create/delete

## Verification

- `cargo test -p arkived-core` — all pass, 1 ignored (Azurite CRUD integration test).
- `cargo clippy -p arkived-core --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo build --workspace` — clean.

## Process

Built via `superpowers:subagent-driven-development`: 20 TDD tasks (test → fail → impl → pass → commit) from `docs/superpowers/plans/2026-04-21-v0.1.0-backend.md`. Haiku for implementation; final opus-eligible review deferred per stacked plan rhythm (CI matrix covers the rest).

## Test plan

- [ ] CI clippy/fmt/test matrix passes on 1.88
- [ ] Linux/macOS/Windows test jobs green
- [ ] Manual smoke test: run Azurite, `cargo test -p arkived-core --test azurite_crud -- --ignored` (optional but recommended)