### PR TITLE
Fix clippy items-after-test-module (red main)

### DIFF
--- a/crates/arkived-core/src/backend/types.rs
+++ b/crates/arkived-core/src/backend/types.rs
@@ -292,6 +292,9 @@ pub struct SasOptions {
     pub ip: Option<String>,
 }
 
+/// Convenience alias for a byte-producing stream.
+pub type ByteStream = BoxStream<'static, crate::Result<Bytes>>;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -341,6 +344,3 @@ mod tests {
         );
     }
 }
-
-/// Convenience alias for a byte-producing stream.
-pub type ByteStream = BoxStream<'static, crate::Result<Bytes>>;


### PR DESCRIPTION
CI's `cargo clippy --workspace --all-targets -- -D warnings` failed on main: the `backend::types` tests module added in #5 sat before the `ByteStream` type alias, tripping `clippy::items-after-test-module`. Moves the alias above the tests module so the test block is last. No behavior change; clippy --all-targets + fmt + 156 tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)