### PR TITLE
CLI: saved-account management (add/use/switch, keychain-backed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "bytes",
  "clap",
  "futures",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/arkived-cli/Cargo.toml
+++ b/crates/arkived-cli/Cargo.toml
@@ -31,6 +31,7 @@ futures = { workspace = true }
 bytes = { workspace = true }
 time = { workspace = true }
 async-trait = { workspace = true }
+secrecy = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/arkived-cli/src/account.rs
+++ b/crates/arkived-cli/src/account.rs
@@ -1,0 +1,274 @@
+//! Saved-account management.
+//!
+//! Lets a user attach a connection under a friendly name, switch between saved
+//! accounts, and have plain commands (`ls`, `cat`, …) use the active one with
+//! no credential flags. Account *metadata* (name, endpoint) lives in the local
+//! SQLite [`Store`]; the *secret* connection parts live only in the OS keychain
+//! via [`OsKeyring`] — never in plaintext on disk.
+//!
+//! The functions take the `Store` and a `&dyn CredentialStore` so they can be
+//! unit-tested with an in-memory store and a fake secret store.
+
+use anyhow::{bail, Context, Result};
+use arkived_core::{
+    ConnectionParts, CredentialStore, CurrentContext, OsKeyring, StorageAccount, Store,
+};
+use secrecy::{ExposeSecret, SecretString};
+use std::path::PathBuf;
+
+/// Keychain service namespace for all arkived secrets.
+const KEYRING_SERVICE: &str = "arkived";
+
+/// Keychain key under which a saved account's [`ConnectionParts`] JSON lives.
+fn secret_key(name: &str) -> String {
+    format!("account:{name}")
+}
+
+/// The OS-keychain secret store used for saved-account credentials.
+pub fn keyring() -> OsKeyring {
+    OsKeyring::new(KEYRING_SERVICE)
+}
+
+/// Resolve the path of the CLI's state database.
+///
+/// Honors `ARKIVED_STORE_PATH` first (used by tests and power users), else a
+/// per-platform data directory: `%APPDATA%` (Windows), `XDG_DATA_HOME` or
+/// `~/.local/share` (Linux), `~/Library/Application Support` (macOS).
+pub fn default_store_path() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("ARKIVED_STORE_PATH") {
+        if !p.is_empty() {
+            return Ok(PathBuf::from(p));
+        }
+    }
+    let base = data_dir().context("could not determine a data directory for the arkived store")?;
+    Ok(base.join("arkived").join("arkived-state.sqlite3"))
+}
+
+#[cfg(target_os = "windows")]
+fn data_dir() -> Option<PathBuf> {
+    std::env::var_os("APPDATA").map(PathBuf::from)
+}
+
+#[cfg(target_os = "macos")]
+fn data_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join("Library/Application Support"))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn data_dir() -> Option<PathBuf> {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
+}
+
+/// Open (creating parent dirs as needed) the CLI's state database.
+pub fn open_store() -> Result<Store> {
+    let path = default_store_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating store directory {}", parent.display()))?;
+    }
+    Store::open(&path).with_context(|| format!("opening store at {}", path.display()))
+}
+
+/// Save `parts` under `name`, replacing any existing account of that name.
+pub fn add(
+    store: &Store,
+    secrets: &dyn CredentialStore,
+    name: &str,
+    parts: &ConnectionParts,
+) -> Result<()> {
+    if parts.is_empty() {
+        bail!(
+            "no connection provided to save. Pass credentials alongside `account add`, e.g.\n  \
+             arkived --connection-string \"...\" account add {name}"
+        );
+    }
+    let json = serde_json::to_string(parts).context("serializing connection parts")?;
+    secrets
+        .put(&secret_key(name), &SecretString::new(json))
+        .context("writing account secret to keychain")?;
+
+    let (_acct_name, endpoint) = parts.summary();
+    let record = StorageAccount {
+        name: name.to_string(),
+        subscription_id: None,
+        kind: "attached".into(),
+        region: String::new(),
+        replication: String::new(),
+        tier: String::new(),
+        hns: false,
+        endpoint: endpoint.unwrap_or_default(),
+        attached_directly: true,
+    };
+    store
+        .storage_account_upsert(&record)
+        .context("saving account metadata")?;
+    Ok(())
+}
+
+/// List all saved accounts.
+pub fn list(store: &Store) -> Result<Vec<StorageAccount>> {
+    store.storage_account_list_all().map_err(Into::into)
+}
+
+/// Make `name` the active account for subsequent commands.
+pub fn use_account(store: &Store, name: &str) -> Result<()> {
+    if store.storage_account_get(name)?.is_none() {
+        bail!("no saved account named '{name}' (see `arkived account list`)");
+    }
+    store.context_set_account(Some(name))?;
+    Ok(())
+}
+
+/// The current selection context (active sign-in / subscription / account).
+pub fn current(store: &Store) -> Result<CurrentContext> {
+    store.context_get().map_err(Into::into)
+}
+
+/// Remove a saved account: its secret, its metadata, and any active selection.
+pub fn forget(store: &Store, secrets: &dyn CredentialStore, name: &str) -> Result<()> {
+    secrets.delete(&secret_key(name))?;
+    store.storage_account_delete(name)?;
+    if store.context_get()?.account_name.as_deref() == Some(name) {
+        store.context_set_account(None)?;
+    }
+    Ok(())
+}
+
+/// Load the active saved account's [`ConnectionParts`], if one is selected.
+///
+/// Returns `Ok(None)` when no account is active. Used by the connection
+/// resolver as a fallback when no explicit credential flags are supplied.
+pub fn active_parts(
+    store: &Store,
+    secrets: &dyn CredentialStore,
+) -> Result<Option<(String, ConnectionParts)>> {
+    let Some(name) = store.context_get()?.account_name else {
+        return Ok(None);
+    };
+    match secrets.get(&secret_key(&name)) {
+        Ok(secret) => {
+            let parts: ConnectionParts = serde_json::from_str(secret.expose_secret())
+                .context("deserializing saved connection parts")?;
+            Ok(Some((name, parts)))
+        }
+        Err(arkived_core::Error::NotFound { .. }) => {
+            bail!("active account '{name}' has no stored credentials; re-add it with `account add`")
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// In-memory `CredentialStore` for tests (no OS keychain).
+    struct FakeSecrets(Mutex<HashMap<String, String>>);
+    impl FakeSecrets {
+        fn new() -> Self {
+            Self(Mutex::new(HashMap::new()))
+        }
+    }
+    impl CredentialStore for FakeSecrets {
+        fn put(&self, key: &str, secret: &SecretString) -> Result<(), arkived_core::Error> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(key.into(), secret.expose_secret().into());
+            Ok(())
+        }
+        fn get(&self, key: &str) -> Result<SecretString, arkived_core::Error> {
+            self.0
+                .lock()
+                .unwrap()
+                .get(key)
+                .map(|s| SecretString::new(s.clone()))
+                .ok_or_else(|| arkived_core::Error::NotFound {
+                    resource: key.into(),
+                })
+        }
+        fn delete(&self, key: &str) -> Result<(), arkived_core::Error> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    fn parts(account: &str) -> ConnectionParts {
+        ConnectionParts {
+            connection_string: Some(format!(
+                "DefaultEndpointsProtocol=https;AccountName={account};AccountKey=dGVzdA==;\
+                 EndpointSuffix=core.windows.net"
+            )),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn add_then_list_and_current() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeSecrets::new();
+        add(&store, &secrets, "prod", &parts("acme")).unwrap();
+
+        let listed = list(&store).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "prod");
+        assert!(listed[0].attached_directly);
+        assert_eq!(listed[0].endpoint, "https://acme.blob.core.windows.net");
+
+        // No account is active until `use`.
+        assert_eq!(current(&store).unwrap().account_name, None);
+    }
+
+    #[test]
+    fn use_unknown_account_errors() {
+        let store = Store::open_in_memory().unwrap();
+        assert!(use_account(&store, "ghost").is_err());
+    }
+
+    #[test]
+    fn use_sets_active_and_active_parts_roundtrips() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeSecrets::new();
+        add(&store, &secrets, "prod", &parts("acme")).unwrap();
+        use_account(&store, "prod").unwrap();
+
+        assert_eq!(
+            current(&store).unwrap().account_name.as_deref(),
+            Some("prod")
+        );
+        let (name, loaded) = active_parts(&store, &secrets).unwrap().unwrap();
+        assert_eq!(name, "prod");
+        assert_eq!(loaded.summary().0.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn active_parts_none_when_nothing_selected() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeSecrets::new();
+        assert!(active_parts(&store, &secrets).unwrap().is_none());
+    }
+
+    #[test]
+    fn forget_removes_secret_metadata_and_active_selection() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeSecrets::new();
+        add(&store, &secrets, "prod", &parts("acme")).unwrap();
+        use_account(&store, "prod").unwrap();
+
+        forget(&store, &secrets, "prod").unwrap();
+        assert!(list(&store).unwrap().is_empty());
+        assert_eq!(current(&store).unwrap().account_name, None);
+        assert!(active_parts(&store, &secrets).unwrap().is_none());
+    }
+
+    #[test]
+    fn add_empty_parts_is_rejected() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeSecrets::new();
+        assert!(add(&store, &secrets, "x", &ConnectionParts::default()).is_err());
+    }
+}

--- a/crates/arkived-cli/src/auth.rs
+++ b/crates/arkived-cli/src/auth.rs
@@ -49,29 +49,45 @@ impl AuthArgs {
         }
     }
 
-    /// Resolve these flags into a connected [`AzureBlobBackend`].
-    pub async fn resolve_backend(&self) -> Result<AzureBlobBackend> {
-        let parts = self.parts();
-        if parts.is_empty() {
-            anyhow::bail!(
-                "no credentials provided. Use one of: --azurite, --connection-string, \
-                 --sas (+ --account/--endpoint), or --account-key --account. \
-                 Env vars ARKIVED_CONNECTION_STRING / ARKIVED_SAS / ARKIVED_ACCOUNT_KEY also work."
-            );
-        }
-        parts.resolve().await.map_err(Into::into)
+    /// The connection parts as supplied by flags/env (no saved-account fallback).
+    /// Used by `account add` to persist exactly what the user passed.
+    pub fn connection_parts(&self) -> ConnectionParts {
+        self.parts()
     }
 
-    /// Resolve these flags into a connected [`AzureQueueBackend`].
-    pub async fn resolve_queue_backend(&self) -> Result<AzureQueueBackend> {
+    /// The effective connection parts: explicit flags/env if present, otherwise
+    /// the active saved account (`account use`). Bails if neither is available.
+    fn effective_parts(&self) -> Result<ConnectionParts> {
         let parts = self.parts();
-        if parts.is_empty() {
-            anyhow::bail!(
-                "no credentials provided. Use --azurite, --connection-string, \
-                 --sas (+ --account/--endpoint), or --account-key --account."
-            );
+        if !parts.is_empty() {
+            return Ok(parts);
         }
-        parts.resolve_queue().await.map_err(Into::into)
+        if let Some((name, saved)) = crate::account::active_parts(
+            &crate::account::open_store()?,
+            &crate::account::keyring(),
+        )? {
+            tracing::debug!(account = %name, "using saved account");
+            return Ok(saved);
+        }
+        anyhow::bail!(
+            "no credentials provided. Use one of: --azurite, --connection-string, \
+             --sas (+ --account/--endpoint), or --account-key --account; or select a saved \
+             account with `arkived account use <name>`. \
+             Env vars ARKIVED_CONNECTION_STRING / ARKIVED_SAS / ARKIVED_ACCOUNT_KEY also work."
+        )
+    }
+
+    /// Resolve into a connected [`AzureBlobBackend`].
+    pub async fn resolve_backend(&self) -> Result<AzureBlobBackend> {
+        self.effective_parts()?.resolve().await.map_err(Into::into)
+    }
+
+    /// Resolve into a connected [`AzureQueueBackend`].
+    pub async fn resolve_queue_backend(&self) -> Result<AzureQueueBackend> {
+        self.effective_parts()?
+            .resolve_queue()
+            .await
+            .map_err(Into::into)
     }
 
     /// A short human label for the active connection (for `doctor`).

--- a/crates/arkived-cli/src/main.rs
+++ b/crates/arkived-cli/src/main.rs
@@ -5,6 +5,7 @@ use arkived_core::config::{ArkivedConfig, ConfirmMode, OutputFormat};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+mod account;
 mod auth;
 mod commands;
 mod output;
@@ -184,10 +185,22 @@ enum Command {
 
 #[derive(Subcommand, Debug)]
 enum AccountAction {
+    /// Save the current connection under a name (credentials go to the OS keychain)
+    Add {
+        /// Friendly name to save this account under
+        name: String,
+    },
     /// List saved storage accounts
     List,
     /// Set the active storage account by name
     Use {
+        /// Storage account name
+        name: String,
+    },
+    /// Show the active sign-in / subscription / account
+    Current,
+    /// Remove a saved account (secret + metadata)
+    Forget {
         /// Storage account name
         name: String,
     },
@@ -467,9 +480,42 @@ async fn dispatch(
             }
         }
         Command::Doctor => commands::doctor(auth).await,
-        Command::Login | Command::Account { .. } => bail!(
-            "saved sign-in / account management lands in the next CLI increment. \
-             For now, connect with --connection-string, --sas, --account-key, or --azurite."
+        Command::Account { action } => {
+            let store = account::open_store()?;
+            let secrets = account::keyring();
+            match action {
+                AccountAction::Add { name } => {
+                    let parts = auth.connection_parts();
+                    account::add(&store, &secrets, &name, &parts)?;
+                    println!("saved account '{name}' (credentials stored in the OS keychain)");
+                    Ok(())
+                }
+                AccountAction::List => output::print_accounts(&account::list(&store)?, format),
+                AccountAction::Use { name } => {
+                    account::use_account(&store, &name)?;
+                    println!("active account is now '{name}'");
+                    Ok(())
+                }
+                AccountAction::Current => {
+                    let ctx = account::current(&store)?;
+                    match ctx.account_name {
+                        Some(name) => println!("active account: {name}"),
+                        None => println!("no active account (use `arkived account use <name>`)"),
+                    }
+                    Ok(())
+                }
+                AccountAction::Forget { name } => {
+                    account::forget(&store, &secrets, &name)?;
+                    println!("forgot account '{name}'");
+                    Ok(())
+                }
+            }
+        }
+        Command::Login => bail!(
+            "interactive Entra (AAD) sign-in is the next increment. For now, save and switch \
+             accounts with `arkived account add <name>` (alongside credentials) and \
+             `arkived account use <name>`, or connect directly with --connection-string, \
+             --sas, --account-key, or --azurite."
         ),
         Command::Mcp => arkived_mcp::run().await,
         Command::ServeAcp => bail!("`arkived serve-acp` is a later milestone (v0.4)."),

--- a/crates/arkived-cli/src/output.rs
+++ b/crates/arkived-cli/src/output.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use arkived_core::config::OutputFormat;
-use arkived_core::{BlobEntry, Container};
+use arkived_core::{BlobEntry, Container, StorageAccount};
 use serde::Serialize;
 
 /// Serialize any value as JSON or YAML. Used for `--format json|yaml` on
@@ -52,6 +52,42 @@ pub fn print_containers(items: &[Container], format: OutputFormat) -> Result<()>
         }
     }
     Ok(())
+}
+
+/// Render a list of saved storage accounts.
+pub fn print_accounts(items: &[StorageAccount], format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(items)?),
+        OutputFormat::Yaml => print!("{}", serde_yaml::to_string(items)?),
+        OutputFormat::Tsv => {
+            println!("NAME\tENDPOINT\tSOURCE");
+            for a in items {
+                println!("{}\t{}\t{}", a.name, a.endpoint, account_source(a));
+            }
+        }
+        OutputFormat::Table => {
+            if items.is_empty() {
+                println!("(no saved accounts — use `arkived account add <name>`)");
+                return Ok(());
+            }
+            let rows: Vec<[String; 3]> = items
+                .iter()
+                .map(|a| [a.name.clone(), a.endpoint.clone(), account_source(a)])
+                .collect();
+            print_table(&["NAME", "ENDPOINT", "SOURCE"], &rows);
+        }
+    }
+    Ok(())
+}
+
+fn account_source(a: &StorageAccount) -> String {
+    if a.attached_directly {
+        "attached".into()
+    } else {
+        a.subscription_id
+            .clone()
+            .unwrap_or_else(|| "sign-in".into())
+    }
 }
 
 /// Render a list of blob entries (blobs and virtual-directory prefixes).

--- a/crates/arkived-core/src/connect.rs
+++ b/crates/arkived-core/src/connect.rs
@@ -10,10 +10,16 @@ use crate::auth::{
 };
 use crate::{AzureBlobBackend, Error};
 use secrecy::SecretString;
+use serde::{Deserialize, Serialize};
 
 /// The set of credential inputs a surface can supply. Resolution tries them in
 /// the documented priority order; the first populated one wins.
-#[derive(Debug, Clone, Default)]
+///
+/// `Serialize`/`Deserialize` exist so a surface can persist a saved account's
+/// parts losslessly into a secret store (the OS keychain) and reload them
+/// later. Because these parts contain secrets, only persist them in the
+/// keychain — never in plaintext on disk.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ConnectionParts {
     /// Full Azure Storage connection string.
     pub connection_string: Option<String>,
@@ -70,6 +76,30 @@ impl ConnectionParts {
         } else {
             "none".into()
         }
+    }
+
+    /// Best-effort `(account_name, blob_endpoint)` derived synchronously with
+    /// no network call, for display and saved-account metadata. Either element
+    /// may be `None` when it can't be determined from the inputs.
+    pub fn summary(&self) -> (Option<String>, Option<String>) {
+        if self.azurite {
+            return (
+                Some("devstoreaccount1".into()),
+                Some(AZURITE_BLOB_ENDPOINT.into()),
+            );
+        }
+        if let Some(cs) = &self.connection_string {
+            if let Ok(parts) = ConnectionStringParts::parse(cs) {
+                let endpoint = self.endpoint.clone().or_else(|| parts.blob_endpoint());
+                return (parts.account_name().map(str::to_string), endpoint);
+            }
+        }
+        let endpoint = self.endpoint.clone().or_else(|| {
+            self.account
+                .as_ref()
+                .map(|a| format!("https://{a}.blob.core.windows.net"))
+        });
+        (self.account.clone(), endpoint)
     }
 
     /// Resolve these parts into a connected [`AzureBlobBackend`].
@@ -204,6 +234,54 @@ mod tests {
             backend.endpoint().as_str(),
             "https://acme.blob.core.windows.net/"
         );
+    }
+
+    #[test]
+    fn summary_from_connection_string() {
+        let parts = ConnectionParts {
+            connection_string: Some(
+                "DefaultEndpointsProtocol=https;AccountName=acme;AccountKey=dGVzdA==;\
+                 EndpointSuffix=core.windows.net"
+                    .into(),
+            ),
+            ..Default::default()
+        };
+        let (name, endpoint) = parts.summary();
+        assert_eq!(name.as_deref(), Some("acme"));
+        assert_eq!(
+            endpoint.as_deref(),
+            Some("https://acme.blob.core.windows.net")
+        );
+    }
+
+    #[test]
+    fn summary_from_account_key_parts() {
+        let parts = ConnectionParts {
+            account: Some("contoso".into()),
+            account_key: Some("a2V5".into()),
+            ..Default::default()
+        };
+        let (name, endpoint) = parts.summary();
+        assert_eq!(name.as_deref(), Some("contoso"));
+        assert_eq!(
+            endpoint.as_deref(),
+            Some("https://contoso.blob.core.windows.net")
+        );
+    }
+
+    #[test]
+    fn parts_roundtrip_through_json() {
+        let parts = ConnectionParts {
+            account: Some("c".into()),
+            sas: Some("sig=abc".into()),
+            endpoint: Some("https://c.blob.core.windows.net".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&parts).unwrap();
+        let back: ConnectionParts = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.account.as_deref(), Some("c"));
+        assert_eq!(back.sas.as_deref(), Some("sig=abc"));
+        assert!(!back.azurite);
     }
 
     #[test]

--- a/crates/arkived-core/src/lib.rs
+++ b/crates/arkived-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod backend;
 // ProgressEvent, ProgressSink, NoopSink, MemorySink) stay reachable via their
 // module path (`arkived_core::store::SignIn` etc.) to keep the top-level namespace
 // focused.
+pub use auth::credentials::{CredentialStore, OsKeyring};
 pub use auth::{AuthProvider, ResolvedCredential};
 pub use backend::{
     AzureBlobBackend, AzureQueueBackend, BlobEntry, BlobPath, BlobProperties, BlobPropertiesUpdate,
@@ -49,5 +50,7 @@ pub use connect::ConnectionParts;
 pub use ctx::{CancellationToken, Ctx};
 pub use error::{Error, Result};
 pub use policy::{Action, ActionContext, Policy, PolicyDecision};
+pub use store::context::CurrentContext;
+pub use store::storage_account::StorageAccount;
 pub use store::Store;
 pub use types::{AuthKind, AzureEnvironment, ResourceKind};


### PR DESCRIPTION
## Summary

Adds **saved-account management** to the CLI so users can attach a connection under a friendly name and switch between accounts — plain commands (`ls`, `cat`, …) then run with no credential flags.

- **Metadata** (name, endpoint) → local SQLite `Store`.
- **Secrets** (the full `ConnectionParts`, serialized) → OS keychain via `OsKeyring`. Never plaintext on disk.

## Commands

```
arkived --connection-string "..." account add prod   # save (creds → keychain)
arkived account list                                 # name / endpoint / source
arkived account use prod                             # make active
arkived account current                              # show active
arkived ls                                           # uses saved account, no flags
arkived account forget prod                          # remove secret + metadata
```

## Implementation

- **core:** `ConnectionParts` gains `Serialize`/`Deserialize` (lossless keychain round-trip) and a sync `summary()` for display metadata. Re-exports `OsKeyring`, `CredentialStore`, `StorageAccount`, `CurrentContext`.
- **cli:** new `account.rs` (add/list/use/current/forget + `active_parts`); `AuthArgs.effective_parts()` falls back to the active saved account when no flags/env are supplied; `output::print_accounts`.
- `account.rs` logic is unit-tested with an in-memory `Store` + a fake secret store (no OS keychain needed in CI).

## Verification

- Unit tests: 159 core + 20 CLI pass; clippy `--all-targets` + fmt clean.
- **Live end-to-end** against Windows Credential Manager: `add → use → ls` (no creds flags — resolved purely from the saved account + keyring) → `forget`, then `ls` fails with a clear message.

## Not in scope

`arkived login` (interactive Entra device-code) remains the next, AAD-gated increment; the device-code provider already exists in core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
