### PR TITLE
CLI: interactive Entra device-code login

### DIFF
--- a/crates/arkived-cli/src/main.rs
+++ b/crates/arkived-cli/src/main.rs
@@ -39,8 +39,12 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Sign in to Azure (interactive AAD device-code flow)
-    Login,
+    /// Sign in to Azure (interactive Entra device-code flow)
+    Login {
+        /// Entra tenant: "organizations" (work/school), "common", "consumers", or a tenant id
+        #[arg(long, default_value = "organizations")]
+        tenant: String,
+    },
     /// Manage saved storage accounts
     Account {
         #[command(subcommand)]
@@ -511,12 +515,32 @@ async fn dispatch(
                 }
             }
         }
-        Command::Login => bail!(
-            "interactive Entra (AAD) sign-in is the next increment. For now, save and switch \
-             accounts with `arkived account add <name>` (alongside credentials) and \
-             `arkived account use <name>`, or connect directly with --connection-string, \
-             --sas, --account-key, or --azurite."
-        ),
+        Command::Login { tenant } => {
+            let store = account::open_store()?;
+            let secrets = account::keyring();
+            let sign_in =
+                arkived_core::auth::entra::login::device_login(&store, &secrets, &tenant, |dc| {
+                    use std::io::Write;
+                    println!(
+                        "\nTo sign in, open:\n  {}\nand enter code:  {}\n",
+                        dc.verification_uri, dc.user_code
+                    );
+                    println!("Waiting for you to finish signing in…");
+                    // Flush so the code shows immediately even when stdout is
+                    // piped (block-buffered), not just on a TTY.
+                    let _ = std::io::stdout().flush();
+                })
+                .await?;
+            println!(
+                "signed in as {} (tenant {})",
+                sign_in.user_principal, sign_in.tenant_id
+            );
+            println!(
+                "note: browsing storage with this sign-in needs account discovery \
+                 (next increment); for now use `account add`/`use` or direct credentials."
+            );
+            Ok(())
+        }
         Command::Mcp => arkived_mcp::run().await,
         Command::ServeAcp => bail!("`arkived serve-acp` is a later milestone (v0.4)."),
         Command::Gui => bail!("`arkived gui` will launch the desktop app in a later milestone."),

--- a/crates/arkived-core/src/auth/entra/claims.rs
+++ b/crates/arkived-core/src/auth/entra/claims.rs
@@ -1,0 +1,112 @@
+//! Reading identity claims from an Entra JWT.
+//!
+//! This does **not** verify the token signature — it only decodes the payload
+//! of a token the authority just issued to us, to label a sign-in with the
+//! user's principal name and tenant. Never use this for authorization.
+
+use base64::Engine;
+use serde::Deserialize;
+
+/// Identity fields extracted from a token, all best-effort.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct IdentityClaims {
+    /// Tenant id (`tid`).
+    pub tenant_id: Option<String>,
+    /// User principal — `preferred_username`, else `upn`/`unique_name`/`email`.
+    pub user_principal: Option<String>,
+    /// Stable user object id (`oid`).
+    pub object_id: Option<String>,
+    /// Display name (`name`).
+    pub name: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawClaims {
+    tid: Option<String>,
+    oid: Option<String>,
+    name: Option<String>,
+    preferred_username: Option<String>,
+    upn: Option<String>,
+    unique_name: Option<String>,
+    email: Option<String>,
+}
+
+/// Parse identity claims from a JWT's payload segment.
+///
+/// Returns defaults if the token isn't a well-formed three-part JWT or the
+/// payload isn't valid base64url-encoded JSON.
+pub fn parse_identity_claims(jwt: &str) -> IdentityClaims {
+    let Some(payload) = jwt.split('.').nth(1) else {
+        return IdentityClaims::default();
+    };
+    let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) else {
+        return IdentityClaims::default();
+    };
+    let Ok(raw) = serde_json::from_slice::<RawClaims>(&bytes) else {
+        return IdentityClaims::default();
+    };
+    IdentityClaims {
+        tenant_id: raw.tid,
+        user_principal: raw
+            .preferred_username
+            .or(raw.upn)
+            .or(raw.unique_name)
+            .or(raw.email),
+        object_id: raw.oid,
+        name: raw.name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fake JWT (`header.payload.sig`) whose payload is `json`.
+    fn jwt_with_payload(json: &str) -> String {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json.as_bytes());
+        format!("aGVhZGVy.{payload}.c2ln")
+    }
+
+    #[test]
+    fn extracts_preferred_username_and_tenant() {
+        let jwt = jwt_with_payload(
+            r#"{"tid":"tenant-1","preferred_username":"hamza@horizon-tech.io","oid":"obj-9","name":"Hamza"}"#,
+        );
+        let c = parse_identity_claims(&jwt);
+        assert_eq!(c.tenant_id.as_deref(), Some("tenant-1"));
+        assert_eq!(c.user_principal.as_deref(), Some("hamza@horizon-tech.io"));
+        assert_eq!(c.object_id.as_deref(), Some("obj-9"));
+        assert_eq!(c.name.as_deref(), Some("Hamza"));
+    }
+
+    #[test]
+    fn falls_back_to_upn_then_unique_name() {
+        let upn = jwt_with_payload(r#"{"upn":"u@x.io"}"#);
+        assert_eq!(
+            parse_identity_claims(&upn).user_principal.as_deref(),
+            Some("u@x.io")
+        );
+        let uniq = jwt_with_payload(r#"{"unique_name":"legacy@x.io"}"#);
+        assert_eq!(
+            parse_identity_claims(&uniq).user_principal.as_deref(),
+            Some("legacy@x.io")
+        );
+    }
+
+    #[test]
+    fn malformed_tokens_yield_defaults() {
+        assert_eq!(parse_identity_claims(""), IdentityClaims::default());
+        assert_eq!(
+            parse_identity_claims("not-a-jwt"),
+            IdentityClaims::default()
+        );
+        assert_eq!(
+            parse_identity_claims("a.!!notbase64!!.c"),
+            IdentityClaims::default()
+        );
+        assert_eq!(
+            parse_identity_claims(&jwt_with_payload("not json")),
+            IdentityClaims::default()
+        );
+    }
+}

--- a/crates/arkived-core/src/auth/entra/login.rs
+++ b/crates/arkived-core/src/auth/entra/login.rs
@@ -1,0 +1,107 @@
+//! Interactive device-code sign-in that persists a [`SignIn`].
+//!
+//! Ties together the raw device-code endpoints, the refresh-token cache, and
+//! the [`Store`] so a CLI/GUI can run one call to sign a user in and remember
+//! them. The display of the verification URL + user code is delegated to the
+//! caller via the `on_prompt` callback, so each front-end controls its own UX.
+
+use crate::auth::credentials::CredentialStore;
+use crate::auth::entra::cache::{CachedRefresh, RefreshCache};
+use crate::auth::entra::claims::parse_identity_claims;
+use crate::auth::entra::device_code::{poll_for_token, start_device_code, DeviceCodeResponse};
+use crate::auth::entra::DEFAULT_CLIENT_ID;
+use crate::store::sign_in::SignIn;
+use crate::store::Store;
+use crate::Error;
+use std::time::Duration;
+use time::OffsetDateTime;
+
+/// Scope requesting a storage access token plus OIDC identity (`openid
+/// profile`) and a refresh token (`offline_access`).
+const LOGIN_SCOPE: &str = "https://storage.azure.com/.default offline_access openid profile";
+
+/// Run an interactive device-code sign-in against `tenant` (`"organizations"`,
+/// `"common"`, `"consumers"`, or a tenant id).
+///
+/// `on_prompt` is invoked once with the verification URL and user code so the
+/// caller can show instructions; the call then blocks until the user completes
+/// authentication or the flow times out. On success it persists a [`SignIn`],
+/// makes it the current sign-in, caches the refresh token in `secrets`, and
+/// returns the record.
+pub async fn device_login<F>(
+    store: &Store,
+    secrets: &dyn CredentialStore,
+    tenant: &str,
+    on_prompt: F,
+) -> Result<SignIn, Error>
+where
+    F: FnOnce(&DeviceCodeResponse),
+{
+    let http = reqwest::Client::new();
+    let client_id = DEFAULT_CLIENT_ID;
+
+    let dc = start_device_code(&http, tenant, client_id, LOGIN_SCOPE).await?;
+    on_prompt(&dc);
+
+    let token = poll_for_token(
+        &http,
+        tenant,
+        client_id,
+        &dc.device_code,
+        Duration::from_secs(dc.interval),
+        Duration::from_secs(dc.expires_in),
+    )
+    .await?;
+
+    // Prefer identity claims from the id_token; fall back to the access token.
+    let mut claims = token
+        .id_token
+        .as_deref()
+        .map(parse_identity_claims)
+        .unwrap_or_default();
+    if claims.user_principal.is_none() {
+        claims = parse_identity_claims(&token.access_token);
+    }
+
+    let tenant_id = claims
+        .tenant_id
+        .clone()
+        .unwrap_or_else(|| tenant.to_string());
+    let user_principal = claims
+        .user_principal
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    // The object id is a stable per-user id; fall back to tenant:user.
+    let sign_in_id = claims
+        .object_id
+        .clone()
+        .unwrap_or_else(|| format!("{tenant_id}:{user_principal}"));
+
+    if let Some(rt) = &token.refresh_token {
+        RefreshCache::new(secrets).put(
+            &sign_in_id,
+            &CachedRefresh {
+                refresh_token: rt.clone(),
+                tenant: tenant_id.clone(),
+                client_id: client_id.to_string(),
+                scope: LOGIN_SCOPE.to_string(),
+                obtained_at: OffsetDateTime::now_utc(),
+            },
+        )?;
+    }
+
+    let record = SignIn::now(
+        &sign_in_id,
+        &user_principal,
+        &tenant_id,
+        "azure",
+        &user_principal,
+    );
+    // Re-signing in with the same identity refreshes the record.
+    if store.sign_in_get(&sign_in_id)?.is_some() {
+        store.sign_in_delete(&sign_in_id)?;
+    }
+    store.sign_in_insert(&record)?;
+    store.context_set_sign_in(Some(&sign_in_id))?;
+    Ok(record)
+}

--- a/crates/arkived-core/src/auth/entra/mod.rs
+++ b/crates/arkived-core/src/auth/entra/mod.rs
@@ -5,8 +5,10 @@
 //! `login.microsoftonline.com`.
 
 pub mod cache;
+pub mod claims;
 pub mod credential;
 pub mod device_code;
+pub mod login;
 
 /// Default Entra client ID used for the device-code flow.
 ///

--- a/crates/arkived-core/src/store/sign_in.rs
+++ b/crates/arkived-core/src/store/sign_in.rs
@@ -23,6 +23,26 @@ pub struct SignIn {
     pub added_at: DateTime<Utc>,
 }
 
+impl SignIn {
+    /// Build a sign-in stamped with the current UTC time.
+    pub fn now(
+        id: impl Into<String>,
+        display_name: impl Into<String>,
+        tenant_id: impl Into<String>,
+        environment: impl Into<String>,
+        user_principal: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            display_name: display_name.into(),
+            tenant_id: tenant_id.into(),
+            environment: environment.into(),
+            user_principal: user_principal.into(),
+            added_at: Utc::now(),
+        }
+    }
+}
+
 impl Store {
     /// Insert a new sign-in. Fails on duplicate `id`.
     pub fn sign_in_insert(&self, s: &SignIn) -> Result<(), Error> {


### PR DESCRIPTION
## Summary

Implements `arkived login` — interactive Microsoft Entra (Azure AD) sign-in via the OAuth 2.0 device-code flow.

```
arkived login                       # tenant defaults to "organizations"
arkived login --tenant common       # or a specific tenant id / "consumers"
```

It prints a verification URL + user code, polls until you authenticate in the browser, then persists a `SignIn` (set as the current sign-in) and caches the refresh token in the OS keychain.

## Implementation

- **core:**
  - `auth/entra/claims.rs` — `parse_identity_claims` reads `tid` / `preferred_username` (→ `upn`/`unique_name`/`email`) / `oid` / `name` from a token's JWT payload. **No signature verification** — it only labels a sign-in we just obtained.
  - `auth/entra/login.rs` — `device_login(store, secrets, tenant, on_prompt)` orchestrates start → display (via callback) → poll → extract identity → cache refresh token → persist `SignIn` → set current. Front-ends own their own prompt UX.
  - `SignIn::now(...)` constructor.
- **cli:** `Login { tenant }` dispatch; flushes the prompt so the code appears immediately even when stdout is piped (block-buffered).

## Verification

- Unit tests: identity-claim parsing incl. fallbacks and malformed tokens. 162 core + 20 CLI pass; clippy `--all-targets` + fmt clean.
- **Live against Microsoft Entra:** the device code is issued and the flow polls correctly (`open https://login.microsoft.com/device, code: …`). The only step that can't be automated is typing the code into a browser.

## Follow-on (not in scope)

Using a sign-in to actually browse storage needs **ARM account discovery** (enumerate subscriptions → storage accounts → endpoints) and wiring the Entra credential into `AuthArgs`. Today, browse via `account add`/`use` or direct credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
