### PR TITLE
CLI: arkived logout (sign out + remove cached token)

### DIFF
--- a/crates/arkived-cli/src/main.rs
+++ b/crates/arkived-cli/src/main.rs
@@ -45,6 +45,8 @@ enum Command {
         #[arg(long, default_value = "organizations")]
         tenant: String,
     },
+    /// Sign out the active Entra sign-in (removes its cached token)
+    Logout,
     /// Manage saved storage accounts
     Account {
         #[command(subcommand)]
@@ -540,6 +542,25 @@ async fn dispatch(
                  (next increment); for now use `account add`/`use` or direct credentials."
             );
             Ok(())
+        }
+        Command::Logout => {
+            let store = account::open_store()?;
+            let secrets = account::keyring();
+            match store.context_get()?.sign_in_id {
+                None => {
+                    println!("no active sign-in");
+                    Ok(())
+                }
+                Some(sign_in_id) => {
+                    let who = store
+                        .sign_in_get(&sign_in_id)?
+                        .map(|s| s.user_principal)
+                        .unwrap_or_else(|| sign_in_id.clone());
+                    arkived_core::auth::entra::login::logout(&store, &secrets, &sign_in_id)?;
+                    println!("signed out {who}");
+                    Ok(())
+                }
+            }
         }
         Command::Mcp => arkived_mcp::run().await,
         Command::ServeAcp => bail!("`arkived serve-acp` is a later milestone (v0.4)."),

--- a/crates/arkived-core/src/auth/entra/login.rs
+++ b/crates/arkived-core/src/auth/entra/login.rs
@@ -105,3 +105,103 @@ where
     store.context_set_sign_in(Some(&sign_in_id))?;
     Ok(record)
 }
+
+/// Sign out a sign-in: delete its cached refresh token and its [`SignIn`]
+/// record, and clear it from the current context if it was active.
+///
+/// Idempotent — deleting an unknown sign-in is not an error.
+pub fn logout(store: &Store, secrets: &dyn CredentialStore, sign_in_id: &str) -> Result<(), Error> {
+    RefreshCache::new(secrets).delete(sign_in_id)?;
+    store.sign_in_delete(sign_in_id)?;
+    if store.context_get()?.sign_in_id.as_deref() == Some(sign_in_id) {
+        store.context_set_sign_in(None)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::{ExposeSecret, SecretString};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct FakeStore(Mutex<HashMap<String, String>>);
+    impl CredentialStore for FakeStore {
+        fn put(&self, key: &str, secret: &SecretString) -> Result<(), Error> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(key.into(), secret.expose_secret().into());
+            Ok(())
+        }
+        fn get(&self, key: &str) -> Result<SecretString, Error> {
+            self.0
+                .lock()
+                .unwrap()
+                .get(key)
+                .map(|s| SecretString::new(s.clone()))
+                .ok_or_else(|| Error::NotFound {
+                    resource: key.into(),
+                })
+        }
+        fn delete(&self, key: &str) -> Result<(), Error> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    fn cached() -> CachedRefresh {
+        CachedRefresh {
+            refresh_token: "rt".into(),
+            tenant: "t".into(),
+            client_id: "c".into(),
+            scope: LOGIN_SCOPE.into(),
+            obtained_at: OffsetDateTime::UNIX_EPOCH,
+        }
+    }
+
+    #[test]
+    fn logout_clears_record_token_and_active_context() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeStore(Mutex::new(HashMap::new()));
+        store
+            .sign_in_insert(&SignIn::now("sid-1", "u@x", "t", "azure", "u@x"))
+            .unwrap();
+        RefreshCache::new(&secrets).put("sid-1", &cached()).unwrap();
+        store.context_set_sign_in(Some("sid-1")).unwrap();
+
+        logout(&store, &secrets, "sid-1").unwrap();
+
+        assert!(store.sign_in_get("sid-1").unwrap().is_none());
+        assert!(RefreshCache::new(&secrets).get("sid-1").unwrap().is_none());
+        assert_eq!(store.context_get().unwrap().sign_in_id, None);
+    }
+
+    #[test]
+    fn logout_leaves_other_active_sign_in_untouched() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeStore(Mutex::new(HashMap::new()));
+        store
+            .sign_in_insert(&SignIn::now("sid-1", "a@x", "t", "azure", "a@x"))
+            .unwrap();
+        store
+            .sign_in_insert(&SignIn::now("sid-2", "b@x", "t", "azure", "b@x"))
+            .unwrap();
+        store.context_set_sign_in(Some("sid-2")).unwrap();
+
+        // Logging out a non-active sign-in must not clear the current context.
+        logout(&store, &secrets, "sid-1").unwrap();
+        assert_eq!(
+            store.context_get().unwrap().sign_in_id.as_deref(),
+            Some("sid-2")
+        );
+    }
+
+    #[test]
+    fn logout_unknown_is_ok() {
+        let store = Store::open_in_memory().unwrap();
+        let secrets = FakeStore(Mutex::new(HashMap::new()));
+        assert!(logout(&store, &secrets, "ghost").is_ok());
+    }
+}


### PR DESCRIPTION
Complements `login`: `arkived logout` removes the active Entra sign-in's cached refresh token from the OS keychain, deletes its `SignIn` record, and clears it from the current context.

- **core:** `auth/entra/login.rs::logout(store, secrets, sign_in_id)` — idempotent; only clears the current context if the signed-out id was the active one. 3 unit tests.
- **cli:** `Command::Logout` resolves the active sign-in, reports the principal, and no-ops cleanly when none is active.

## Verification
- 165 core + 20 CLI tests pass; clippy `--all-targets` + fmt clean.
- **Live:** used it to sign out the real Entra session from the earlier login verification — confirmed the keychain token, `sign_in` row, and `current_sign_in` were all removed, and a second run reports `no active sign-in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)