### PR TITLE
Desktop: auto-update via the Tauri updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: ./app
           tagName: app-v__VERSION__
@@ -100,5 +102,5 @@ jobs:
             - **Linux aarch64** — `*_aarch64.AppImage`, `*_arm64.deb`, or `*.aarch64.rpm`
           releaseDraft: true
           prerelease: false
-          includeUpdaterJson: false
+          includeUpdaterJson: true
           args: ${{ matrix.args }}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.0",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1333,6 +1335,24 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
       "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -73,6 +73,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arkived-app"
 version = "0.0.1"
 dependencies = [
@@ -91,6 +100,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "time",
  "tokio",
  "url",
@@ -1115,6 +1126,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1449,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2854,6 +2886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3193,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +3315,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4122,6 +4186,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4129,12 +4194,15 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4268,6 +4336,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4356,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -5019,6 +5126,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5195,6 +5313,49 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -6224,6 +6385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6968,6 +7138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7144,6 +7324,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -43,6 +43,8 @@ url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 webbrowser = "1"
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 
 [features]
 default = ["custom-protocol"]

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Default capabilities for the Arkived desktop app.",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "updater:default", "process:default"]
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -16,6 +16,8 @@ use tauri::{Emitter, Manager};
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             let app_data_dir = app
                 .path()
@@ -82,6 +84,8 @@ pub fn run() {
             let help_menu = SubmenuBuilder::new(app, "Help")
                 .text("help.docs", "Documentation")
                 .text("help.shortcuts", "Keyboard Shortcuts")
+                .text("help.check-updates", "Check for Updates…")
+                .separator()
                 .text("help.about", "About arkived")
                 .build()?;
 

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -29,6 +29,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -51,6 +52,14 @@
       "deb": {
         "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
       }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/Horizon-Tech-doo/arkived/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI2Q0I3RThBNzRGM0NDOUYKUldTZnpQTjBpbjdMSnVZU2tBdWtJMUcrSy9JT3Zna0U3eUpPQXljSWVpcnN0QjJBci8yWENkM0IK"
     }
   }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,8 @@ import type { BlobPropertiesPaneState } from "./content";
 import { ActivityBar, CommandPalette } from "./panels";
 import type { CommandItem } from "./panels";
 import { useDialogs } from "./dialogs";
+import { checkForUpdate, installUpdate } from "./lib/updater";
+import type { Update } from "@tauri-apps/plugin-updater";
 import type { Activity, BlobRow } from "./data";
 import {
   IconAlert,
@@ -463,6 +465,10 @@ function App() {
   const previewRequestId = useRef(0);
   const blobSelectionAnchors = useRef<Record<string, number>>({});
   const menuActionRef = useRef<(id: string) => void>(() => undefined);
+  const [pendingUpdate, setPendingUpdate] = useState<{ version: string; notes: string } | null>(null);
+  const [updateBusy, setUpdateBusy] = useState(false);
+  const [updateProgress, setUpdateProgress] = useState<number | null>(null);
+  const updateHandleRef = useRef<Update | null>(null);
 
   browserTabsRef.current = browserTabs;
   connectionsRef.current = connections;
@@ -3158,6 +3164,14 @@ function App() {
     { id: "view.details", section: "View", label: "Toggle details panel", icon: <IconInfo size={12} />, run: () => setShowDetails((value) => !value) },
     { id: "view.activities", section: "View", label: "Toggle activities", icon: <IconTerminal size={12} />, run: () => setShowActivities((value) => !value) },
   );
+  paletteCommands.push({
+    id: "app.check-updates",
+    section: "Help",
+    label: "Check for updates",
+    keywords: "update upgrade version",
+    icon: <IconRefresh size={12} />,
+    run: () => void handleCheckForUpdates(true),
+  });
   if (activeConnection && activeContainer) {
     paletteCommands.push(
       { id: "blob.upload", section: "Storage", label: "Upload files…", icon: <IconUpload size={12} />, run: () => void handleUploadFiles() },
@@ -3479,6 +3493,50 @@ function App() {
           ? shellError
           : "Attach a storage account";
 
+  async function handleCheckForUpdates(manual = false) {
+    if (!tauriAvailable.current) {
+      if (manual) {
+        setShellError("Auto-update is only available in the desktop app.");
+      }
+      return;
+    }
+    try {
+      const update = await checkForUpdate();
+      if (update) {
+        updateHandleRef.current = update;
+        setPendingUpdate({ version: update.version, notes: update.body ?? "" });
+      } else {
+        updateHandleRef.current = null;
+        setPendingUpdate(null);
+        if (manual) {
+          setShellError(`You're on the latest version (v${APP_VERSION}).`);
+        }
+      }
+    } catch (error) {
+      if (manual) {
+        setShellError(`Update check failed: ${getErrorMessage(error)}`);
+      }
+    }
+  }
+
+  async function handleInstallUpdate() {
+    const update = updateHandleRef.current;
+    if (!update || updateBusy) {
+      return;
+    }
+    setUpdateBusy(true);
+    setUpdateProgress(0);
+    setShellError(null);
+    try {
+      // On success the app relaunches into the new version inside installUpdate.
+      await installUpdate(update, (percent) => setUpdateProgress(percent));
+    } catch (error) {
+      setShellError(`Update failed: ${getErrorMessage(error)}`);
+      setUpdateBusy(false);
+      setUpdateProgress(null);
+    }
+  }
+
   menuActionRef.current = (id: string) => {
     switch (id) {
       case "file.connect":
@@ -3565,6 +3623,9 @@ function App() {
       case "edit.select-all":
         handleToggleSelectAll();
         break;
+      case "help.check-updates":
+        void handleCheckForUpdates(true);
+        break;
       case "help.docs":
         window.open("https://github.com", "_blank", "noopener,noreferrer");
         break;
@@ -3630,6 +3691,12 @@ function App() {
         unlisten();
       }
     };
+  }, []);
+
+  // Silent auto-update check on launch; surfaces a banner if a newer build exists.
+  useEffect(() => {
+    void handleCheckForUpdates(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -4878,6 +4945,44 @@ function App() {
               Drop to upload to <strong style={{ color: "var(--fg-0)" }}>{dropTarget.label}</strong>
             </span>
           </div>
+        </div>
+      )}
+
+      {pendingUpdate && (
+        <div style={styles.updateBanner}>
+          <IconRefresh size={14} style={{ color: "var(--accent)", flexShrink: 0 }} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+            <span style={{ color: "var(--fg-0)", fontWeight: 600 }}>
+              Arkived v{pendingUpdate.version} is available
+            </span>
+            <span style={{ color: "var(--fg-3)", fontSize: 11 }}>
+              {updateBusy
+                ? updateProgress == null
+                  ? "Downloading update…"
+                  : `Downloading update… ${updateProgress}%`
+                : `You're on v${APP_VERSION}`}
+            </span>
+          </div>
+          <div style={{ flex: 1 }} />
+          {!updateBusy && (
+            <>
+              <button
+                type="button"
+                style={styles.secondaryButton}
+                onClick={() => setPendingUpdate(null)}
+              >
+                Later
+              </button>
+              <button
+                type="button"
+                style={styles.primaryButton}
+                onClick={() => void handleInstallUpdate()}
+              >
+                <IconDownload size={12} />
+                <span>Update &amp; restart</span>
+              </button>
+            </>
+          )}
         </div>
       )}
 
@@ -8064,6 +8169,22 @@ const styles: Record<string, CSSProperties> = {
     color: "var(--fg-2)",
     fontSize: 13,
     boxShadow: "0 12px 36px rgba(0,0,0,0.4)",
+  },
+  updateBanner: {
+    position: "fixed",
+    right: 16,
+    bottom: 16,
+    zIndex: 40,
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    width: "min(440px, calc(100% - 32px))",
+    padding: "12px 14px",
+    borderRadius: 8,
+    border: "1px solid var(--accent-dim)",
+    background: "var(--bg-1)",
+    fontSize: 13,
+    boxShadow: "0 16px 44px rgba(0,0,0,0.45)",
   },
   overviewHeader: {
     display: "flex",

--- a/app/src/lib/updater.ts
+++ b/app/src/lib/updater.ts
@@ -1,0 +1,39 @@
+// Arkived — desktop auto-update helpers (Tauri updater plugin).
+//
+// check() asks the configured endpoint (the GitHub Releases `latest.json`)
+// whether a newer signed build exists. downloadAndInstall() fetches it,
+// verifies its signature against the bundled public key, installs it, and we
+// relaunch into the new version.
+
+import type { Update } from "@tauri-apps/plugin-updater";
+
+export async function checkForUpdate(): Promise<Update | null> {
+  const { check } = await import("@tauri-apps/plugin-updater");
+  return check();
+}
+
+export async function installUpdate(
+  update: Update,
+  onProgress?: (percent: number | null) => void,
+): Promise<void> {
+  const { relaunch } = await import("@tauri-apps/plugin-process");
+  let downloaded = 0;
+  let total = 0;
+  await update.downloadAndInstall((event) => {
+    switch (event.event) {
+      case "Started":
+        total = event.data.contentLength ?? 0;
+        onProgress?.(total ? 0 : null);
+        break;
+      case "Progress":
+        downloaded += event.data.chunkLength;
+        onProgress?.(total ? Math.min(100, Math.round((downloaded / total) * 100)) : null);
+        break;
+      case "Finished":
+        onProgress?.(100);
+        break;
+    }
+  });
+  // The new version is installed; restart into it.
+  await relaunch();
+}


### PR DESCRIPTION
## Summary

Makes the desktop app self-updating. On launch — and via **Help → Check for Updates…** or the command palette — Arkived checks the GitHub Releases `latest.json`. If a newer **signed** build exists, it shows a banner to download it, verify its signature against the bundled public key, install, and relaunch into the new version.

## Changes

- **Plugins:** `tauri-plugin-updater` + `tauri-plugin-process` (Rust + JS), wired in `lib.rs`, with `updater:default` / `process:default` capabilities.
- **Config:** `plugins.updater` endpoint (`releases/latest/download/latest.json`) + signing **public** key; `bundle.createUpdaterArtifacts: true`.
- **Frontend:** `app/src/lib/updater.ts` (check → `downloadAndInstall` with progress → `relaunch`); a silent startup check, a bottom-right update banner with a progress percentage, a Help menu item, and a "Check for updates" palette command.
- **Release workflow:** now signs artifacts (`TAURI_SIGNING_PRIVATE_KEY` / `_PASSWORD` secrets — already configured in repo settings) and emits `latest.json` (`includeUpdaterJson: true`).

## Verification

- `tsc` + `vite` build clean; `cargo check` passes (plugins compile, capabilities validate).
- A **signed** local `tauri build` produced the NSIS + MSI installers **and** their `.sig` updater signatures — confirming the end-to-end sign → bundle path.

## Rollout note (bootstrapping)

Auto-update only activates from a release whose binary **contains** this updater code. So after merge:

1. Cut a new signed release (e.g. bump to `app-v0.0.2`) — it's signed and ships `latest.json`.
2. **Publish** it (the `latest.json` endpoint resolves to the latest *published* release).
3. From `v0.0.2` onward, installed apps auto-update to `v0.0.3+`.

The current `v0.0.1` (built before the updater) can't self-update; those users grab `v0.0.2` manually once, then it's automatic.