### PR TITLE
Desktop: rich account Properties (keys + connection string) + runtime version

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -191,6 +191,8 @@ struct DiscoveredStorageAccount {
     hns: bool,
     endpoint: String,
     resource_id: Option<String>,
+    #[serde(default)]
+    access_tier: Option<String>,
 }
 
 #[derive(Clone)]
@@ -459,6 +461,8 @@ struct ArmStorageAccountProperties {
     is_hns_enabled: Option<bool>,
     #[serde(rename = "primaryEndpoints", default)]
     primary_endpoints: Option<ArmPrimaryEndpoints>,
+    #[serde(rename = "accessTier", default)]
+    access_tier: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -5856,6 +5860,11 @@ async fn discover_storage_accounts(
                 .unwrap_or(false),
             endpoint,
             resource_id: account.id,
+            access_tier: account
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.access_tier.clone())
+                .filter(|value| !value.trim().is_empty()),
         });
     }
 
@@ -6335,6 +6344,219 @@ async fn request_storage_account_key(
             "ARM `listKeys` succeeded, but Azure did not return a usable storage account key."
                 .to_string()
         })
+}
+
+/// Full storage-account properties for the Properties panel, including the
+/// account keys + primary connection string (returned only when the signed-in
+/// user is allowed to list keys).
+#[derive(Serialize)]
+pub struct AccountProperties {
+    name: String,
+    kind: String,
+    region: String,
+    replication: String,
+    tier: String,
+    access_tier: Option<String>,
+    hns: bool,
+    resource_group: Option<String>,
+    subscription_id: String,
+    blob_endpoint: String,
+    queue_endpoint: String,
+    table_endpoint: String,
+    file_endpoint: String,
+    primary_key: Option<String>,
+    secondary_key: Option<String>,
+    primary_connection_string: Option<String>,
+    keys_error: Option<String>,
+}
+
+fn resource_group_from_id(resource_id: &str) -> Option<String> {
+    let lower = resource_id.to_ascii_lowercase();
+    let marker = "/resourcegroups/";
+    let start = lower.find(marker)? + marker.len();
+    let rest = &resource_id[start..];
+    let end = rest.find('/').unwrap_or(rest.len());
+    let group = rest[..end].trim();
+    if group.is_empty() {
+        None
+    } else {
+        Some(group.to_string())
+    }
+}
+
+/// Derive a sibling service endpoint (queue/table/file) from the blob endpoint
+/// by swapping the service token in the host, falling back to the standard
+/// `{account}.{service}.core.windows.net` form.
+fn derive_service_endpoint(blob_endpoint: &str, account_name: &str, service: &str) -> String {
+    if blob_endpoint.contains(".blob.") {
+        blob_endpoint.replacen(".blob.", &format!(".{service}."), 1)
+    } else {
+        format!("https://{account_name}.{service}.core.windows.net/")
+    }
+}
+
+/// ARM `listKeys` returning both the primary and (when present) secondary key.
+async fn request_storage_account_keys(
+    bundle: &TokenBundle,
+    resource_id: &str,
+) -> Result<(String, Option<String>), String> {
+    let refresh_context = bundle.refresh_context.as_ref().ok_or_else(|| {
+        "this sign-in no longer has HTTP context for Azure Resource Manager key requests"
+            .to_string()
+    })?;
+    let url = format!(
+        "https://management.azure.com{resource_id}/listKeys?api-version={ARM_STORAGE_ACCOUNTS_API_VERSION}"
+    );
+    let response = refresh_context
+        .client
+        .post(&url)
+        .bearer_auth(&bundle.access_token)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .map_err(|error| format!("ARM `listKeys` request failed: {error}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|error| format!("ARM `listKeys` response could not be read: {error}"))?;
+    if !status.is_success() {
+        return Err(compact_arm_list_keys_error(status.as_u16(), &body));
+    }
+    let parsed = serde_json::from_str::<ArmListKeysResponse>(&body)
+        .map_err(|error| format!("ARM `listKeys` response could not be parsed: {error}"))?;
+    let mut values = parsed.keys.into_iter().filter_map(|key| {
+        let value = key.value?.trim().to_string();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    });
+    let primary = values.next().ok_or_else(|| {
+        "ARM `listKeys` succeeded, but Azure did not return a usable storage account key."
+            .to_string()
+    })?;
+    Ok((primary, values.next()))
+}
+
+/// Obtain both account keys, trying the same ARM token sources as the
+/// activation path (cached tenant token, initial login token, fresh mint).
+async fn try_fetch_storage_account_keys(
+    sign_in: &SignInSession,
+    tenant_id: &str,
+    account: &DiscoveredStorageAccount,
+) -> Result<(String, Option<String>), String> {
+    let resource_id = account
+        .resource_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "Azure Resource Manager did not return a resource ID for this storage account, so Arkived could not request account keys.".to_string()
+        })?;
+
+    let mut attempts = Vec::new();
+    if let Some(bundle) = sign_in.tenant_bundles.get(tenant_id) {
+        attempts.push(bundle.clone());
+    }
+    if sign_in
+        .arm_bundle
+        .refresh_context
+        .as_ref()
+        .map(|ctx| ctx.tenant.eq_ignore_ascii_case(tenant_id))
+        .unwrap_or(false)
+    {
+        attempts.push(sign_in.arm_bundle.clone());
+    }
+
+    let mut last_error = None;
+    for bundle in attempts {
+        match request_storage_account_keys(&bundle, resource_id).await {
+            Ok(keys) => return Ok(keys),
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    let arm_scope = scope_with_refresh(ARM_SCOPE);
+    match mint_sign_in_scoped_bundle(sign_in, tenant_id, &arm_scope).await {
+        Ok(bundle) => request_storage_account_keys(&bundle, resource_id).await,
+        Err(error) => Err(last_error.unwrap_or_else(|| compact_arm_token_error(&error))),
+    }
+}
+
+/// Full Properties for a discovered storage account, including keys + the
+/// primary connection string (best-effort; metadata is still returned if the
+/// user lacks permission to list keys).
+#[tauri::command]
+pub async fn get_account_properties(
+    state: State<'_, AppState>,
+    sign_in_id: String,
+    subscription_id: String,
+    account_name: String,
+) -> Result<AccountProperties, String> {
+    let sign_in = get_sign_in(&state, &sign_in_id)?;
+    let (target_tenant_id, account) = sign_in
+        .tenants
+        .iter()
+        .find_map(|tenant| {
+            tenant
+                .subscriptions
+                .iter()
+                .find(|subscription| subscription.id == subscription_id)
+                .and_then(|subscription| {
+                    subscription
+                        .storage_accounts
+                        .iter()
+                        .find(|account| account.name == account_name)
+                        .cloned()
+                        .map(|account| (tenant.id.clone(), account))
+                })
+        })
+        .ok_or_else(|| {
+            format!("unknown storage account `{account_name}` in subscription `{subscription_id}`")
+        })?;
+
+    let blob_endpoint = account.endpoint.clone();
+    let queue_endpoint = derive_service_endpoint(&blob_endpoint, &account.name, "queue");
+    let table_endpoint = derive_service_endpoint(&blob_endpoint, &account.name, "table");
+    let file_endpoint = derive_service_endpoint(&blob_endpoint, &account.name, "file");
+    let resource_group = account
+        .resource_id
+        .as_deref()
+        .and_then(resource_group_from_id);
+
+    let (primary_key, secondary_key, primary_connection_string, keys_error) =
+        match try_fetch_storage_account_keys(&sign_in, &target_tenant_id, &account).await {
+            Ok((primary, secondary)) => {
+                let connection_string = format!(
+                    "DefaultEndpointsProtocol=https;AccountName={};AccountKey={};EndpointSuffix=core.windows.net",
+                    account.name, primary
+                );
+                (Some(primary), secondary, Some(connection_string), None)
+            }
+            Err(error) => (None, None, None, Some(error)),
+        };
+
+    Ok(AccountProperties {
+        name: account.name.clone(),
+        kind: account.kind.clone(),
+        region: account.region.clone(),
+        replication: account.replication.clone(),
+        tier: account.tier.clone(),
+        access_tier: account.access_tier.clone(),
+        hns: account.hns,
+        resource_group,
+        subscription_id,
+        blob_endpoint,
+        queue_endpoint,
+        table_endpoint,
+        file_endpoint,
+        primary_key,
+        secondary_key,
+        primary_connection_string,
+        keys_error,
+    })
 }
 
 fn compact_arm_list_keys_error(status: u16, body: &str) -> String {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -118,6 +118,7 @@ pub fn run() {
             commands::update_sign_in_filter,
             commands::list_subscriptions,
             commands::list_discovered_storage_accounts,
+            commands::get_account_properties,
             commands::connect_connection_string,
             commands::connect_account_key,
             commands::connect_sas,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -309,7 +309,9 @@ interface PersistedShellSnapshot {
 }
 
 const SHELL_STATE_STORAGE_KEY = "arkived.shell.v1";
-const APP_VERSION = "0.0.1";
+// Fallback only (browser/dev). The desktop app overrides this at runtime with
+// the real version from Tauri's getVersion(), so it never goes stale on release.
+const APP_VERSION = "0.0.2";
 const SIDEBAR_DEFAULT_WIDTH = 340;
 const SIDEBAR_MIN_WIDTH = 260;
 const SIDEBAR_MAX_WIDTH = 640;
@@ -465,6 +467,7 @@ function App() {
   const previewRequestId = useRef(0);
   const blobSelectionAnchors = useRef<Record<string, number>>({});
   const menuActionRef = useRef<(id: string) => void>(() => undefined);
+  const [appVersion, setAppVersion] = useState(APP_VERSION);
   const [pendingUpdate, setPendingUpdate] = useState<{ version: string; notes: string } | null>(null);
   const [updateBusy, setUpdateBusy] = useState(false);
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
@@ -3509,7 +3512,7 @@ function App() {
         updateHandleRef.current = null;
         setPendingUpdate(null);
         if (manual) {
-          setShellError(`You're on the latest version (v${APP_VERSION}).`);
+          setShellError(`You're on the latest version (v${appVersion}).`);
         }
       }
     } catch (error) {
@@ -3648,10 +3651,10 @@ function App() {
       case "help.about":
         setInfoModal({
           title: "Arkived",
-          subtitle: `Version ${APP_VERSION}`,
+          subtitle: `Version ${appVersion}`,
           rows: [
             { label: "App", value: "Arkived" },
-            { label: "Version", value: APP_VERSION },
+            { label: "Version", value: appVersion },
             { label: "Runtime", value: tauriAvailable.current ? "Tauri desktop shell" : "Browser (Vite dev)" },
             { label: "Description", value: "Azure Blob Storage explorer" },
           ],
@@ -3693,6 +3696,18 @@ function App() {
     };
   }, []);
 
+  // Read the real app version from Tauri so version labels never go stale.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { getVersion } = await import("@tauri-apps/api/app");
+        setAppVersion(await getVersion());
+      } catch {
+        // Not running under Tauri (e.g. plain Vite dev); keep the fallback.
+      }
+    })();
+  }, []);
+
   // Silent auto-update check on launch; surfaces a banner if a newer build exists.
   useEffect(() => {
     void handleCheckForUpdates(false);
@@ -3707,6 +3722,7 @@ function App() {
         connectionDetail={connectionDetail}
         connected={Boolean(activeConnection || signIns.length > 0) && !runtimeUnavailable}
         statusText={statusText}
+        version={appVersion}
         onRefresh={() => {
           void handleRefresh();
         }}
@@ -4960,7 +4976,7 @@ function App() {
                 ? updateProgress == null
                   ? "Downloading update…"
                   : `Downloading update… ${updateProgress}%`
-                : `You're on v${APP_VERSION}`}
+                : `You're on v${appVersion}`}
             </span>
           </div>
           <div style={{ flex: 1 }} />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -81,6 +81,7 @@ import {
   listConnections,
   listContainers,
   listDiscoveredStorageAccounts,
+  getAccountProperties,
   listSignIns,
   listSignInTenants,
   pollEntraBrowserLogin,
@@ -188,10 +189,18 @@ interface ContextMenuState {
   items: ContextMenuItem[];
 }
 
+interface InfoModalRow {
+  label: string;
+  value: string;
+  secret?: boolean;
+  copyable?: boolean;
+}
+
 interface InfoModalState {
   title: string;
   subtitle?: string;
-  rows: { label: string; value: string }[];
+  rows: InfoModalRow[];
+  loading?: boolean;
 }
 
 interface DropTarget {
@@ -446,6 +455,7 @@ function App() {
   const [showDetails, setShowDetails] = useState(true);
   const [showActivities, setShowActivities] = useState(true);
   const [infoModal, setInfoModal] = useState<InfoModalState | null>(null);
+  const [revealedSecrets, setRevealedSecrets] = useState<Set<string>>(new Set());
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
   const [dropActive, setDropActive] = useState(false);
@@ -2311,20 +2321,84 @@ function App() {
     });
   }
 
-  function showAccountProperties(account: BrowserStorageAccount) {
+  async function showAccountProperties(account: BrowserStorageAccount) {
+    setRevealedSecrets(new Set());
+    // Metadata we already have; shown immediately while keys/connection string load.
+    const baseRows: InfoModalRow[] = [
+      { label: "Account name", value: account.name, copyable: true },
+      { label: "Kind", value: account.kind },
+      { label: "Location", value: account.region },
+      { label: "Replication", value: account.replication },
+      { label: "SKU tier", value: account.tier },
+      {
+        label: "Hierarchical namespace",
+        value: account.hns ? "Enabled (ADLS Gen2)" : "Disabled",
+      },
+      { label: "Blob endpoint", value: account.endpoint, copyable: true },
+    ];
     setInfoModal({
       title: account.name,
       subtitle: "Storage account",
-      rows: [
-        { label: "Name", value: account.name },
-        { label: "Kind", value: account.kind },
-        { label: "Region", value: account.region },
-        { label: "Replication", value: account.replication },
-        { label: "Tier", value: account.tier },
-        { label: "Hierarchical namespace", value: account.hns ? "Enabled (ADLS Gen2)" : "Disabled" },
-        { label: "Endpoint", value: account.endpoint },
-      ],
+      rows: baseRows,
+      loading: tauriAvailable.current,
     });
+    if (!tauriAvailable.current) {
+      return;
+    }
+    try {
+      const props = await getAccountProperties(
+        account.sign_in_id,
+        account.subscription_id,
+        account.name,
+      );
+      const rows: InfoModalRow[] = [
+        { label: "Account name", value: props.name, copyable: true },
+        { label: "Subscription", value: props.subscription_id, copyable: true },
+        { label: "Resource group", value: props.resource_group ?? "—", copyable: !!props.resource_group },
+        { label: "Location", value: props.region },
+        { label: "Account kind", value: props.kind },
+        { label: "SKU tier", value: props.tier },
+        { label: "Replication", value: props.replication },
+        { label: "Default access tier", value: props.access_tier ?? "—" },
+        { label: "Hierarchical namespace", value: props.hns ? "Enabled (ADLS Gen2)" : "Disabled" },
+        { label: "Blob endpoint", value: props.blob_endpoint, copyable: true },
+        { label: "Queue endpoint", value: props.queue_endpoint, copyable: true },
+        { label: "Table endpoint", value: props.table_endpoint, copyable: true },
+        { label: "File endpoint", value: props.file_endpoint, copyable: true },
+      ];
+      if (props.primary_key) {
+        rows.push({ label: "Primary key", value: props.primary_key, secret: true, copyable: true });
+      }
+      if (props.secondary_key) {
+        rows.push({ label: "Secondary key", value: props.secondary_key, secret: true, copyable: true });
+      }
+      if (props.primary_connection_string) {
+        rows.push({
+          label: "Primary connection string",
+          value: props.primary_connection_string,
+          secret: true,
+          copyable: true,
+        });
+      }
+      if (props.keys_error) {
+        rows.push({ label: "Keys", value: `Unavailable — ${props.keys_error}` });
+      }
+      setInfoModal((current) =>
+        current && current.title === account.name
+          ? { ...current, rows, loading: false }
+          : current,
+      );
+    } catch (error) {
+      setInfoModal((current) =>
+        current && current.title === account.name
+          ? {
+              ...current,
+              loading: false,
+              rows: [...baseRows, { label: "Details", value: `Unavailable — ${getErrorMessage(error)}` }],
+            }
+          : current,
+      );
+    }
   }
 
   async function handleDeletePrefix(row: BlobRow) {
@@ -3948,7 +4022,7 @@ function App() {
                                     {
                                       label: "Properties",
                                       action: () => {
-                                        showAccountProperties(account);
+                                        void showAccountProperties(account);
                                       },
                                     },
                                   ])
@@ -4904,7 +4978,7 @@ function App() {
         <div style={styles.overlay} onClick={() => setInfoModal(null)}>
           <div
             style={{
-              width: "min(520px, 100%)",
+              width: "min(620px, 100%)",
               borderRadius: 6,
               overflow: "hidden",
               border: "1px solid var(--border-1)",
@@ -4924,30 +4998,77 @@ function App() {
                 Close
               </button>
             </div>
-            <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 12 }}>
-              {infoModal.rows.map((entry) => (
-                <div
-                  key={entry.label}
-                  style={{ display: "flex", gap: 16, alignItems: "baseline" }}
-                >
+            <div style={{ padding: 20, display: "flex", flexDirection: "column", gap: 8, maxHeight: "60vh", overflow: "auto" }}>
+              {infoModal.rows.map((entry) => {
+                const revealed = revealedSecrets.has(entry.label);
+                const display = entry.secret && !revealed ? "•".repeat(16) : entry.value;
+                return (
                   <div
-                    style={{
-                      width: 150,
-                      flexShrink: 0,
-                      fontFamily: "var(--mono)",
-                      fontSize: 11,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.06em",
-                      color: "var(--fg-3)",
-                    }}
+                    key={entry.label}
+                    style={{ display: "flex", gap: 14, alignItems: "baseline" }}
                   >
-                    {entry.label}
+                    <div
+                      style={{
+                        width: 168,
+                        flexShrink: 0,
+                        fontFamily: "var(--mono)",
+                        fontSize: 11,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.06em",
+                        color: "var(--fg-3)",
+                      }}
+                    >
+                      {entry.label}
+                    </div>
+                    <div
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        color: "var(--fg-1)",
+                        fontSize: 13,
+                        fontFamily: entry.secret ? "var(--mono)" : undefined,
+                        wordBreak: "break-all",
+                      }}
+                    >
+                      {display}
+                    </div>
+                    {entry.secret && (
+                      <button
+                        type="button"
+                        style={styles.propsRowButton}
+                        onClick={() =>
+                          setRevealedSecrets((current) => {
+                            const next = new Set(current);
+                            if (next.has(entry.label)) {
+                              next.delete(entry.label);
+                            } else {
+                              next.add(entry.label);
+                            }
+                            return next;
+                          })
+                        }
+                      >
+                        {revealed ? "Hide" : "Show"}
+                      </button>
+                    )}
+                    {entry.copyable && (
+                      <button
+                        type="button"
+                        style={styles.propsRowButton}
+                        onClick={() => void copyText(entry.value)}
+                      >
+                        Copy
+                      </button>
+                    )}
                   </div>
-                  <div style={{ color: "var(--fg-1)", fontSize: 13, wordBreak: "break-all" }}>
-                    {entry.value}
-                  </div>
+                );
+              })}
+              {infoModal.loading && (
+                <div style={{ display: "flex", alignItems: "center", gap: 8, color: "var(--fg-3)", fontSize: 12, paddingTop: 4 }}>
+                  <IconLoader size={12} />
+                  <span>Loading keys and endpoints…</span>
                 </div>
-              ))}
+              )}
             </div>
           </div>
         </div>
@@ -8413,6 +8534,18 @@ const styles: Record<string, CSSProperties> = {
     color: "var(--fg-1)",
     fontFamily: "var(--mono)",
     fontSize: 11,
+  },
+  propsRowButton: {
+    flexShrink: 0,
+    height: 24,
+    padding: "0 8px",
+    borderRadius: 4,
+    border: "1px solid var(--border-1)",
+    background: "var(--bg-2)",
+    color: "var(--fg-2)",
+    fontFamily: "var(--mono)",
+    fontSize: 10,
+    cursor: "pointer",
   },
   dialogContent: {
     flex: 1,

--- a/app/src/chrome.tsx
+++ b/app/src/chrome.tsx
@@ -17,6 +17,7 @@ interface TitleBarProps {
   connectionDetail?: string;
   connected?: boolean;
   statusText?: string;
+  version?: string;
   onRefresh?: () => void;
   onOpenSettings?: () => void;
 }
@@ -28,6 +29,7 @@ export function TitleBar({
   connectionDetail = "No endpoint selected",
   connected = true,
   statusText = "connected",
+  version,
   onRefresh,
   onOpenSettings,
 }: TitleBarProps) {
@@ -37,7 +39,7 @@ export function TitleBar({
         <div style={titlebarStyles.brandBlock}>
           <IconLogo size={14} color="var(--accent)" />
           <span style={titlebarStyles.brandName}>arkived</span>
-          <span style={titlebarStyles.version}>v0.3.1</span>
+          {version && <span style={titlebarStyles.version}>v{version}</span>}
         </div>
 
         <div style={titlebarStyles.sep} />

--- a/app/src/lib/ipc.ts
+++ b/app/src/lib/ipc.ts
@@ -58,6 +58,38 @@ export interface BrowserStorageAccount {
   endpoint: string;
 }
 
+export interface AccountProperties {
+  name: string;
+  kind: string;
+  region: string;
+  replication: string;
+  tier: string;
+  access_tier?: string | null;
+  hns: boolean;
+  resource_group?: string | null;
+  subscription_id: string;
+  blob_endpoint: string;
+  queue_endpoint: string;
+  table_endpoint: string;
+  file_endpoint: string;
+  primary_key?: string | null;
+  secondary_key?: string | null;
+  primary_connection_string?: string | null;
+  keys_error?: string | null;
+}
+
+export async function getAccountProperties(
+  signInId: string,
+  subscriptionId: string,
+  accountName: string,
+): Promise<AccountProperties> {
+  return callTauri<AccountProperties>("get_account_properties", {
+    signInId,
+    subscriptionId,
+    accountName,
+  });
+}
+
 export interface BrowserContainer {
   id: string;
   name: string;


### PR DESCRIPTION
Addresses two reported items.

## 1. Rich storage-account Properties (Azure Storage Explorer parity)

Selecting **Properties** on a storage account now shows the full picture, not just 7 fields:

- **Metadata:** Account name, Subscription, Resource group, Location, Account kind, SKU tier, Replication, Default access tier, HNS, and all four service endpoints (Blob / Queue / Table / File).
- **Secrets:** **Primary Key**, **Secondary Key**, and **Primary Connection String** — masked by default, with per-row **Show/Hide** and **Copy**.

Metadata renders instantly; keys + connection string load via a new `get_account_properties` command (ARM `listKeys` for both keys, reusing the activation-path token sources). Keys are **best-effort** — if the signed-in user can't list keys, the metadata still shows and the reason is surfaced.

Backend: parse `accessTier`, thread it through the discovered-account model, derive queue/table/file endpoints from the blob endpoint, parse the resource group from the resource ID, and build the connection string.

## 2. Fix stale version labels

The title bar (hardcoded `v0.3.1`) and the update-check message (`v0.0.1`) were hardcoded and went stale — so on v0.0.2 the update check still said "you're on the latest version (v0.0.1)". Now the real version is read at runtime from Tauri's `getVersion()` and used everywhere (title bar, About, update banner/messages).

## Verification

`cargo check` (src-tauri), `tsc --noEmit`, and `npm run build` all pass. The account-keys path needs a live Entra sign-in to exercise end-to-end (will verify after release).